### PR TITLE
Merge favorite places in route suggestions + geo link handler, lat lon input, map rotation, switch input focus, ticket price info, real time badge

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,16 @@
                     android:scheme="transportia"
                     android:host="trip"/>
             </intent-filter>
+            <intent-filter>
+                <action
+                    android:name="android.intent.action.VIEW"/>
+                <category
+                    android:name="android.intent.category.DEFAULT"/>
+                <category
+                    android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="geo"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,6 +61,14 @@
 					<string>transportia</string>
 				</array>
 			</dict>
+			<dict>
+				<key>CFBundleURLName</key>
+				<string>transportia.geo</string>
+				<key>CFBundleURLSchemes</key>
+				<array>
+					<string>geo</string>
+				</array>
+			</dict>
 		</array>
 	</dict>
 </plist>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,15 +2,20 @@ import 'dart:async';
 
 import 'package:app_links/app_links.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
 import 'package:oktoast/oktoast.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'environment.dart';
 import 'constants/prefs_keys.dart';
+import 'models/time_selection.dart';
 import 'providers/backend_provider.dart';
 import 'providers/theme_provider.dart';
+import 'screens/itinerary_list_screen.dart';
 import 'screens/main_navigation_screen.dart';
 import 'screens/welcome_screen.dart';
+import 'services/location_service.dart';
+import 'services/transitous_geocode_service.dart';
 import 'widgets/offline_banner_shell.dart';
 
 class Transportia extends StatelessWidget {
@@ -128,11 +133,62 @@ class _RootGateState extends State<_RootGate> {
   }
 
   void _handleIncomingDeepLink(Uri uri) {
+    if (uri.scheme == 'geo') {
+      _handleGeoLink(uri);
+      return;
+    }
     if (uri.scheme != 'transportia' || uri.host != 'trip') {
       return;
     }
     debugPrint('Received ${Environment.appName} trip link: ${uri.toString()}');
     // TODO: this
+  }
+
+  void _handleGeoLink(Uri uri) {
+    final destination = _parseGeoUri(uri);
+    if (destination == null) {
+      debugPrint('Unable to parse geo link: $uri');
+      return;
+    }
+    debugPrint('Received geo link: $uri');
+
+    final currentPosition = LocationService.currentPosition();
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (_) => ItineraryListScreen(
+          fromLat: currentPosition.then((position) => position.latitude),
+          fromLon: currentPosition.then((position) => position.longitude),
+          toLat: destination.latitude,
+          toLon: destination.longitude,
+          timeSelection: TimeSelection.now(),
+        ),
+      ),
+    );
+  }
+
+  /// Parses `geo:lat,lon` and `geo:0,0?q=lat,lon(label)` URIs, the two
+  /// forms produced by Android/iOS when a `geo:` link is shared or tapped.
+  LatLng? _parseGeoUri(Uri uri) {
+    final direct = TransitousGeocodeService.tryParseLatLon(uri.path);
+    if (direct != null && (direct.latitude != 0 || direct.longitude != 0)) {
+      return direct;
+    }
+
+    final query = uri.queryParameters['q'];
+    if (query != null) {
+      final match = RegExp(
+        r'^\s*(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)',
+      ).firstMatch(query);
+      if (match != null) {
+        final lat = double.tryParse(match.group(1)!);
+        final lon = double.tryParse(match.group(2)!);
+        if (lat != null && lon != null) {
+          return LatLng(lat, lon);
+        }
+      }
+    }
+
+    return null;
   }
 
   @override

--- a/lib/models/itinerary.dart
+++ b/lib/models/itinerary.dart
@@ -14,6 +14,69 @@ class FareInfo {
   }
 }
 
+class TicketProduct {
+  final String name;
+  final double amount;
+  final String currency;
+  final String? fareMediaName;
+  final String? fareMediaType;
+
+  TicketProduct({
+    required this.name,
+    required this.amount,
+    required this.currency,
+    this.fareMediaName,
+    this.fareMediaType,
+  });
+
+  factory TicketProduct.fromJson(Map<String, dynamic> json) {
+    final media = json['media'];
+    final Map<String, dynamic> mediaMap = media is Map<String, dynamic>
+        ? media
+        : {};
+    return TicketProduct(
+      name: json['name'] ?? '',
+      amount: json['amount']?.toDouble() ?? 0.0,
+      currency: json['currency'] ?? '',
+      fareMediaName: mediaMap['fareMediaName'],
+      fareMediaType: mediaMap['fareMediaType'],
+    );
+  }
+}
+
+class FareOption {
+  final List<TicketProduct> products;
+
+  FareOption({required this.products});
+
+  factory FareOption.fromJson(List<dynamic> json) {
+    return FareOption(
+      products: json
+          .whereType<Map<String, dynamic>>()
+          .map((p) => TicketProduct.fromJson(p))
+          .toList(),
+    );
+  }
+}
+
+class FareLegInfo {
+  final List<String> routeShortNames;
+  final List<FareOption> options;
+
+  FareLegInfo({required this.routeShortNames, required this.options});
+
+  String get _optionsKey => options
+      .map(
+        (o) => o.products
+            .map(
+              (p) =>
+                  '${p.name}|${p.amount}|${p.currency}|${p.fareMediaName}|${p.fareMediaType}',
+            )
+            .join(','),
+      )
+      .join(';');
+}
+
 class Alert {
   final String? cause;
   final String? causeDetail;
@@ -132,6 +195,7 @@ class Itinerary {
   final List<Leg> legs;
   final bool isDirect;
   final FareInfo? fare;
+  final List<FareLegInfo> ticketInfo;
 
   Itinerary({
     required this.duration,
@@ -141,7 +205,10 @@ class Itinerary {
     required this.legs,
     this.isDirect = false,
     this.fare,
+    this.ticketInfo = const [],
   });
+
+  bool get hasTicketInfo => ticketInfo.isNotEmpty;
 
   double get walkingDistance {
     double totalDistance = 0.0;
@@ -174,7 +241,12 @@ class Itinerary {
     Map<String, dynamic> json, {
     bool isDirect = false,
   }) {
+    final legs = (json['legs'] as List)
+        .map((leg) => Leg.fromJson(leg))
+        .toList();
+
     FareInfo? fare;
+    var ticketInfo = <FareLegInfo>[];
     if (json['fareTransfers'] != null &&
         (json['fareTransfers'] as List).isNotEmpty) {
       final fareTransfer = (json['fareTransfers'] as List).first;
@@ -184,6 +256,73 @@ class Itinerary {
           (fareTransfer['transferProducts'] as List).first,
         );
       }
+
+      try {
+        final routeNamesByFareLeg = <String, List<String>>{};
+        for (final leg in legs) {
+          if (leg.fareTransferIndex == null ||
+              leg.effectiveFareLegIndex == null) {
+            continue;
+          }
+          final name = leg.routeShortName ?? leg.displayName;
+          if (name == null || name.isEmpty) continue;
+          final key = '${leg.fareTransferIndex}:${leg.effectiveFareLegIndex}';
+          final names = routeNamesByFareLeg.putIfAbsent(key, () => []);
+          if (!names.contains(name)) names.add(name);
+        }
+
+        final rawTicketInfo = <FareLegInfo>[];
+        final transfers = json['fareTransfers'] as List;
+        for (var t = 0; t < transfers.length; t++) {
+          final legProducts = transfers[t]['effectiveFareLegProducts'];
+          if (legProducts is! List) continue;
+          for (var i = 0; i < legProducts.length; i++) {
+            final legOptions = legProducts[i];
+            if (legOptions is! List) continue;
+            final options = legOptions
+                .whereType<List<dynamic>>()
+                .map((o) => FareOption.fromJson(o))
+                .where((o) => o.products.isNotEmpty)
+                .toList();
+            if (options.isEmpty) continue;
+            rawTicketInfo.add(
+              FareLegInfo(
+                routeShortNames: routeNamesByFareLeg['$t:$i'] ?? const [],
+                options: options,
+              ),
+            );
+          }
+        }
+
+        // Merge fare legs that share identical ticket options.
+        final mergedByKey = <String, FareLegInfo>{};
+        final order = <String>[];
+        for (final entry in rawTicketInfo) {
+          final key = entry._optionsKey;
+          final existing = mergedByKey[key];
+          if (existing == null) {
+            mergedByKey[key] = entry;
+            order.add(key);
+          } else {
+            final combinedNames = [...existing.routeShortNames];
+            for (final name in entry.routeShortNames) {
+              if (!combinedNames.contains(name)) combinedNames.add(name);
+            }
+            mergedByKey[key] = FareLegInfo(
+              routeShortNames: combinedNames,
+              options: existing.options,
+            );
+          }
+        }
+        ticketInfo = order.map((key) => mergedByKey[key]!).toList();
+      } catch (e, stackTrace) {
+        developer.log(
+          'Error parsing ticket info',
+          name: 'Itinerary',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
     }
 
     return Itinerary(
@@ -191,9 +330,10 @@ class Itinerary {
       startTime: DateTime.parse(json['startTime']),
       endTime: DateTime.parse(json['endTime']),
       transfers: json['transfers'] ?? 0,
-      legs: (json['legs'] as List).map((leg) => Leg.fromJson(leg)).toList(),
+      legs: legs,
       isDirect: isDirect,
       fare: fare,
+      ticketInfo: ticketInfo,
     );
   }
 }
@@ -234,6 +374,8 @@ class Leg {
   final List<Alert> alerts;
   final EncodedPolyline? legGeometry;
   final bool interlineWithPreviousLeg;
+  final int? fareTransferIndex;
+  final int? effectiveFareLegIndex;
 
   Leg({
     required this.mode,
@@ -271,6 +413,8 @@ class Leg {
     this.alerts = const [],
     this.legGeometry,
     this.interlineWithPreviousLeg = false,
+    this.fareTransferIndex,
+    this.effectiveFareLegIndex,
   });
 
   factory Leg.fromJson(Map<String, dynamic> json) {
@@ -370,6 +514,8 @@ class Leg {
         alerts: alerts,
         legGeometry: legGeometry,
         interlineWithPreviousLeg: json['interlineWithPreviousLeg'] ?? false,
+        fareTransferIndex: json['fareTransferIndex'],
+        effectiveFareLegIndex: json['effectiveFareLegIndex'],
       );
     } catch (e, stackTrace) {
       developer.log(

--- a/lib/screens/favourites_map_screen.dart
+++ b/lib/screens/favourites_map_screen.dart
@@ -50,7 +50,7 @@ class _AddFavouriteMapScreenState extends State<AddFavouriteMapScreen> {
                       zoom: 13.0,
                     ),
                     myLocationEnabled: true,
-                    rotateGesturesEnabled: false,
+                    rotateGesturesEnabled: true,
                     tiltGesturesEnabled: false,
                     compassEnabled: false,
                     onMapClick: _onMapTap,

--- a/lib/screens/itinerary_detail_screen.dart
+++ b/lib/screens/itinerary_detail_screen.dart
@@ -50,59 +50,79 @@ class _ItineraryDetailScreenState extends State<ItineraryDetailScreen> {
             ),
             JourneyOverviewWidget(itinerary: widget.itinerary),
             Expanded(
-              child: displayLegs.isEmpty
-                  ? Center(
-                      child: Text(
-                        'No additional steps required for this journey.',
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: AppColors.black.withValues(alpha: 0.4),
-                        ),
-                      ),
-                    )
-                  : Builder(
-                      builder: (context) {
-                        final hasFinishCard = widget.itinerary.legs.isNotEmpty;
-                        final finishInsertIndex = displayLegs.length;
-                        final shareIndex =
-                            finishInsertIndex + (hasFinishCard ? 1 : 0);
-                        final totalItems = shareIndex + 1;
+              child: Builder(
+                builder: (context) {
+                  final hasTicketInfo = widget.itinerary.hasTicketInfo;
+                  final ticketInsertIndex = hasTicketInfo ? 1 : 0;
+                  final hasFinishCard = widget.itinerary.legs.isNotEmpty;
+                  final legsInsertIndex = ticketInsertIndex;
+                  final emptyMessageIndex = displayLegs.isEmpty
+                      ? legsInsertIndex
+                      : -1;
+                  final legsEndIndex =
+                      legsInsertIndex +
+                      (displayLegs.isEmpty ? 1 : displayLegs.length);
+                  final finishInsertIndex = legsEndIndex;
+                  final shareIndex =
+                      finishInsertIndex + (hasFinishCard ? 1 : 0);
+                  final totalItems = shareIndex + 1;
 
-                        return ListView.builder(
-                          padding: const EdgeInsets.only(bottom: 16),
-                          itemCount: totalItems,
-                          itemBuilder: (context, index) {
-                            if (index < displayLegs.length) {
-                              final entry = displayLegs[index];
-                              if (entry.isTransfer) {
-                                return TransferLegCard(leg: entry.leg);
-                              }
-                              return LegDetailsWidget(leg: entry.leg);
-                            }
-
-                            if (hasFinishCard && index == finishInsertIndex) {
-                              final finishLeg = widget.itinerary.legs.last;
-                              return FinishLegCard(
-                                leg: finishLeg,
-                                arrivalTime: widget.itinerary.endTime,
-                                totalDuration: widget.itinerary.duration,
-                              );
-                            }
-
-                            if (index == shareIndex) {
-                              return LoadMoreButton(
-                                onTap: _shareItinerary,
-                                isLoading: _isSharing,
-                                label: 'Share this trip',
-                                icon: LucideIcons.share2,
-                              );
-                            }
-
-                            return const SizedBox.shrink();
-                          },
+                  return ListView.builder(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    itemCount: totalItems,
+                    itemBuilder: (context, index) {
+                      if (hasTicketInfo && index == 0) {
+                        return TicketInfoCard(
+                          ticketInfo: widget.itinerary.ticketInfo,
                         );
-                      },
-                    ),
+                      }
+
+                      if (index == emptyMessageIndex) {
+                        return Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Center(
+                            child: Text(
+                              'No additional steps required for this journey.',
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: AppColors.black.withValues(alpha: 0.4),
+                              ),
+                            ),
+                          ),
+                        );
+                      }
+
+                      if (index >= legsInsertIndex && index < legsEndIndex) {
+                        final entry = displayLegs[index - legsInsertIndex];
+                        if (entry.isTransfer) {
+                          return TransferLegCard(leg: entry.leg);
+                        }
+                        return LegDetailsWidget(leg: entry.leg);
+                      }
+
+                      if (hasFinishCard && index == finishInsertIndex) {
+                        final finishLeg = widget.itinerary.legs.last;
+                        return FinishLegCard(
+                          leg: finishLeg,
+                          arrivalTime: widget.itinerary.endTime,
+                          totalDuration: widget.itinerary.duration,
+                        );
+                      }
+
+                      if (index == shareIndex) {
+                        return LoadMoreButton(
+                          onTap: _shareItinerary,
+                          isLoading: _isSharing,
+                          label: 'Share this trip',
+                          icon: LucideIcons.share2,
+                        );
+                      }
+
+                      return const SizedBox.shrink();
+                    },
+                  );
+                },
+              ),
             ),
           ],
         ),
@@ -292,6 +312,149 @@ class JourneyOverviewWidget extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class TicketInfoCard extends StatefulWidget {
+  final List<FareLegInfo> ticketInfo;
+
+  const TicketInfoCard({super.key, required this.ticketInfo});
+
+  @override
+  State<TicketInfoCard> createState() => _TicketInfoCardState();
+}
+
+class _TicketInfoCardState extends State<TicketInfoCard> {
+  bool _isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => setState(() => _isExpanded = !_isExpanded),
+      child: CustomCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  LucideIcons.ticket,
+                  size: 18,
+                  color: AppColors.accentOf(context),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Ticket information',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.black,
+                    ),
+                  ),
+                ),
+                Icon(
+                  _isExpanded
+                      ? LucideIcons.chevronUp
+                      : LucideIcons.chevronDown,
+                  size: 16,
+                  color: AppColors.accentOf(context),
+                ),
+              ],
+            ),
+            if (_isExpanded) ...[
+              const SizedBox(height: 12),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+                child: SizedBox(
+                  height: 1,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(color: Color(0x33000000)),
+                  ),
+                ),
+              ),
+              ...widget.ticketInfo.map(_buildFareLegOptions),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFareLegOptions(FareLegInfo legInfo) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (legInfo.routeShortNames.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Text(
+                'Valid for ${legInfo.routeShortNames.join(' & ')}',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.black.withValues(alpha: 0.5),
+                ),
+              ),
+            ),
+          ...legInfo.options.map(_buildFareOption),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFareOption(FareOption option) {
+    final label = option.products.map((p) => p.name).join(' + ');
+    final price = option.products
+        .map((p) => '${p.amount.toStringAsFixed(2)} ${p.currency}')
+        .join(' + ');
+    final media = option.products
+        .map((p) => p.fareMediaName)
+        .whereType<String>()
+        .where((m) => m.isNotEmpty)
+        .toSet()
+        .join(', ');
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: AppColors.black.withValues(alpha: 0.8),
+                  ),
+                ),
+                if (media.isNotEmpty)
+                  Text(
+                    media,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: AppColors.black.withValues(alpha: 0.5),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Text(
+            price,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: AppColors.black,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/itinerary_list_screen.dart
+++ b/lib/screens/itinerary_list_screen.dart
@@ -426,7 +426,14 @@ class ItineraryCard extends StatelessWidget {
                         color: AppColors.black.withValues(alpha: 0.8),
                       ),
                     ),
+                    const SizedBox(width: 12),
                   ],
+                  if (itinerary.hasTicketInfo)
+                    Icon(
+                      LucideIcons.ticket,
+                      size: 16,
+                      color: AppColors.black.withValues(alpha: 0.6),
+                    ),
                 ],
               ),
               Row(

--- a/lib/screens/itinerary_list_screen.dart
+++ b/lib/screens/itinerary_list_screen.dart
@@ -281,6 +281,10 @@ class ItineraryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final delaySummary = _delaySummaryLabel();
     final departInLabel = _departInLabel();
+    final firstNonWalkingLeg = itinerary.legs
+        .where((leg) => leg.mode != 'WALK')
+        .firstOrNull;
+    final hasFirstLegRealTime = firstNonWalkingLeg?.realTime ?? false;
     return CustomCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -309,6 +313,12 @@ class ItineraryCard extends StatelessWidget {
                         color: AppColors.black.withValues(alpha: 0.7),
                       ),
                     ),
+                    if (hasFirstLegRealTime)
+                      Icon(
+                        LucideIcons.wifi,
+                        size: 14,
+                        color: AppColors.accentOf(context),
+                      ),
                   ],
                 ),
               ),

--- a/lib/screens/itinerary_map_screen.dart
+++ b/lib/screens/itinerary_map_screen.dart
@@ -112,7 +112,7 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
                     initialCameraPosition: _calculateInitialCamera(),
                     myLocationEnabled: true,
                     myLocationRenderMode: MyLocationRenderMode.compass,
-                    rotateGesturesEnabled: false,
+                    rotateGesturesEnabled: true,
                     tiltGesturesEnabled: false,
                     compassEnabled: false,
                   ),

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -2362,7 +2362,11 @@ class _MapScreenState extends State<MapScreen>
     unawaited(_recordSavedPlace(suggestion));
     _setControllerText(field, suggestion.name);
     _setSelection(field, suggestion, notify: true);
-    _unfocusInputs();
+    if (field == RouteFieldKind.from && _toCtrl.text.trim().isEmpty) {
+      _toFocus.requestFocus();
+    } else {
+      _unfocusInputs();
+    }
   }
 
   void _setControllerText(RouteFieldKind kind, String value) {

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -2112,6 +2112,14 @@ class _MapScreenState extends State<MapScreen>
     final current = _selectionFor(kind);
     if (current != null) return current;
     final query = _controllerFor(kind).text.trim();
+    final coord = TransitousGeocodeService.tryParseLatLon(query);
+    if (coord != null) {
+      final suggestion = TransitousLocationSuggestion.fromLatLon(coord);
+      if (!mounted) return suggestion;
+      _setControllerText(kind, suggestion.name);
+      _setSelection(kind, suggestion, notify: true);
+      return suggestion;
+    }
     if (query.length < 3) return null;
 
     try {
@@ -2250,6 +2258,17 @@ class _MapScreenState extends State<MapScreen>
 
   void _requestSuggestions(RouteFieldKind kind, String text) {
     final query = text.trim();
+    final coord = TransitousGeocodeService.tryParseLatLon(query);
+    if (coord != null) {
+      ++_suggestionRequestId;
+      setState(() {
+        _activeSuggestionField = kind;
+        _suggestions = [TransitousLocationSuggestion.fromLatLon(coord)];
+        _isFetchingSuggestions = false;
+      });
+      _notifyOverlayVisibility();
+      return;
+    }
     if (query.length < 3) {
       if (_activeSuggestionField == kind) {
         setState(() {

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1692,7 +1692,7 @@ class _MapScreenState extends State<MapScreen>
                         : MyLocationRenderMode.normal,
                     myLocationTrackingMode: MyLocationTrackingMode.none,
                     trackCameraPosition: true,
-                    rotateGesturesEnabled: false,
+                    rotateGesturesEnabled: true,
                     tiltGesturesEnabled: false,
                     initialCameraPosition: _startCam,
                     compassEnabled: false,

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1973,6 +1973,7 @@ class _MapScreenState extends State<MapScreen>
                                     toController: _toCtrl,
                                     suggestions: _suggestions,
                                     savedPlaces: _savedSearchPlaces,
+                                    favorites: _favorites,
                                     isLoading: _isFetchingSuggestions,
                                     onSuggestionTap: _onSuggestionSelected,
                                     onDismissRequest: _unfocusInputs,
@@ -3960,6 +3961,7 @@ class _MapScreenState extends State<MapScreen>
   Future<void> _recordSavedPlace(
     TransitousLocationSuggestion suggestion,
   ) async {
+    if (suggestion.id.startsWith('fav-')) return;
     final name = suggestion.name.trim();
     if (name.isEmpty) return;
     final selected = SavedPlace(

--- a/lib/services/transitous_geocode_service.dart
+++ b/lib/services/transitous_geocode_service.dart
@@ -55,6 +55,17 @@ class TransitousLocationSuggestion {
     return 3;
   }
 
+  factory TransitousLocationSuggestion.fromLatLon(LatLng latLng) {
+    return TransitousLocationSuggestion(
+      id: _fallbackId(latLng.latitude, latLng.longitude),
+      name:
+          '${latLng.latitude.toStringAsFixed(6)}, ${latLng.longitude.toStringAsFixed(6)}',
+      lat: latLng.latitude,
+      lon: latLng.longitude,
+      type: 'COORDINATE',
+    );
+  }
+
   factory TransitousLocationSuggestion.fromJson(Map<String, dynamic> json) {
     final areas = json['areas'];
     String? defaultArea;
@@ -87,6 +98,20 @@ class TransitousLocationSuggestion {
 }
 
 class TransitousGeocodeService {
+  static final RegExp _latLonPattern = RegExp(
+    r'^\s*(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)\s*$',
+  );
+
+  static LatLng? tryParseLatLon(String text) {
+    final match = _latLonPattern.firstMatch(text);
+    if (match == null) return null;
+    final lat = double.tryParse(match.group(1)!);
+    final lon = double.tryParse(match.group(2)!);
+    if (lat == null || lon == null) return null;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+    return LatLng(lat, lon);
+  }
+
   static Future<List<TransitousLocationSuggestion>> fetchSuggestions({
     required String text,
     LatLng? placeBias,

--- a/lib/widgets/route_suggestions_overlay.dart
+++ b/lib/widgets/route_suggestions_overlay.dart
@@ -2,8 +2,10 @@ import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../models/route_field_kind.dart';
 import '../models/saved_place.dart';
+import '../services/favorites_service.dart';
 import '../services/transitous_geocode_service.dart';
 import '../theme/app_colors.dart';
+import '../utils/favorite_icons.dart';
 import '../utils/haptics.dart';
 
 class RouteSuggestionsOverlay extends StatelessWidget {
@@ -15,6 +17,7 @@ class RouteSuggestionsOverlay extends StatelessWidget {
     required this.toController,
     required this.suggestions,
     required this.savedPlaces,
+    required this.favorites,
     required this.isLoading,
     required this.onSuggestionTap,
     required this.onDismissRequest,
@@ -27,6 +30,7 @@ class RouteSuggestionsOverlay extends StatelessWidget {
   final TextEditingController toController;
   final List<TransitousLocationSuggestion> suggestions;
   final List<SavedPlace> savedPlaces;
+  final List<FavoritePlace> favorites;
   final bool isLoading;
   final void Function(
     RouteFieldKind field,
@@ -52,6 +56,7 @@ class RouteSuggestionsOverlay extends StatelessWidget {
       query: controller.text.trim(),
       suggestions: suggestions,
       savedPlaces: savedPlaces,
+      favorites: favorites,
       isLoading: isLoading,
       onSuggestionTap: (suggestion) => onSuggestionTap(field, suggestion),
       onDismissRequest: onDismissRequest,
@@ -66,6 +71,7 @@ class SingleFieldSuggestionsOverlay extends StatelessWidget {
     required this.controller,
     required this.suggestions,
     required this.savedPlaces,
+    this.favorites = const [],
     required this.isLoading,
     required this.onSuggestionTap,
     required this.onDismissRequest,
@@ -76,6 +82,7 @@ class SingleFieldSuggestionsOverlay extends StatelessWidget {
   final TextEditingController controller;
   final List<TransitousLocationSuggestion> suggestions;
   final List<SavedPlace> savedPlaces;
+  final List<FavoritePlace> favorites;
   final bool isLoading;
   final ValueChanged<TransitousLocationSuggestion> onSuggestionTap;
   final VoidCallback onDismissRequest;
@@ -89,6 +96,7 @@ class SingleFieldSuggestionsOverlay extends StatelessWidget {
       query: controller.text.trim(),
       suggestions: suggestions,
       savedPlaces: savedPlaces,
+      favorites: favorites,
       isLoading: isLoading,
       onSuggestionTap: onSuggestionTap,
       onDismissRequest: onDismissRequest,
@@ -103,6 +111,7 @@ class _SuggestionsOverlayCard extends StatelessWidget {
     required this.query,
     required this.suggestions,
     required this.savedPlaces,
+    required this.favorites,
     required this.isLoading,
     required this.onSuggestionTap,
     required this.onDismissRequest,
@@ -113,6 +122,7 @@ class _SuggestionsOverlayCard extends StatelessWidget {
   final String query;
   final List<TransitousLocationSuggestion> suggestions;
   final List<SavedPlace> savedPlaces;
+  final List<FavoritePlace> favorites;
   final bool isLoading;
   final ValueChanged<TransitousLocationSuggestion> onSuggestionTap;
   final VoidCallback onDismissRequest;
@@ -120,21 +130,29 @@ class _SuggestionsOverlayCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final savedMatches = _filterSavedPlaces(savedPlaces, query);
+    final favMatches = _filterFavorites(favorites, query);
 
     Widget body;
     final bool hasFullQuery = query.length >= 3;
-    final bool showSaved = !hasFullQuery && savedMatches.isNotEmpty;
-    final bool hasResults = hasFullQuery && suggestions.isNotEmpty;
-    final bool showLoading = hasFullQuery && isLoading;
+    final bool hasFavMatches = favMatches.isNotEmpty;
+    final bool showSaved =
+        !hasFullQuery && (hasFavMatches || savedMatches.isNotEmpty);
+    final bool hasResults =
+        hasFullQuery && (suggestions.isNotEmpty || hasFavMatches);
+    final bool showLoading = hasFullQuery && isLoading && !hasFavMatches;
 
     if (showSaved) {
+      final combined = [
+        ...favMatches.map(_favToSuggestion),
+        ...savedMatches.map(_toSuggestion),
+      ];
       body = ListView.separated(
         padding: EdgeInsets.zero,
         shrinkWrap: true,
-        itemCount: savedMatches.length,
+        itemCount: combined.length,
         separatorBuilder: (_, __) => const SizedBox(height: 10),
         itemBuilder: (context, index) {
-          final suggestion = _toSuggestion(savedMatches[index]);
+          final suggestion = combined[index];
           return _SuggestionTile(
             suggestion: suggestion,
             onTap: () => onSuggestionTap(suggestion),
@@ -160,13 +178,14 @@ class _SuggestionsOverlayCard extends StatelessWidget {
         ),
       );
     } else {
+      final merged = [...favMatches.map(_favToSuggestion), ...suggestions];
       body = ListView.separated(
         padding: EdgeInsets.zero,
         shrinkWrap: true,
-        itemCount: suggestions.length,
+        itemCount: merged.length,
         separatorBuilder: (_, __) => const SizedBox(height: 10),
         itemBuilder: (context, index) {
-          final suggestion = suggestions[index];
+          final suggestion = merged[index];
           return _SuggestionTile(
             suggestion: suggestion,
             onTap: () => onSuggestionTap(suggestion),
@@ -226,6 +245,27 @@ class _SuggestionsOverlayCard extends StatelessWidget {
       child: card,
     );
   }
+}
+
+List<FavoritePlace> _filterFavorites(List<FavoritePlace> favs, String query) {
+  if (favs.isEmpty) return <FavoritePlace>[];
+  final trimmed = query.trim().toLowerCase();
+  final filtered = trimmed.isEmpty
+      ? favs
+      : favs.where((f) => f.name.toLowerCase().contains(trimmed)).toList();
+  return filtered.take(5).toList(growable: false);
+}
+
+TransitousLocationSuggestion _favToSuggestion(FavoritePlace fav) {
+  return TransitousLocationSuggestion(
+    id: 'fav-${fav.id}',
+    name: fav.name,
+    lat: fav.lat,
+    lon: fav.lon,
+    type: fav.iconName,
+    country: null,
+    defaultArea: null,
+  );
 }
 
 List<SavedPlace> _filterSavedPlaces(List<SavedPlace> places, String query) {
@@ -393,6 +433,6 @@ class _SuggestionTile extends StatelessWidget {
     if (type.contains('stop')) return LucideIcons.bus;
     if (type.contains('place')) return LucideIcons.map;
     if (type.contains('address')) return LucideIcons.locateFixed;
-    return LucideIcons.mapPin;
+    return iconForFavorite(rawType);
   }
 }


### PR DESCRIPTION
Includes the content of my previous PR #19 
- Add geo link handler - other apps linking to GPS locations can directly open Transportia with destination search pre-filled in
- Allow lat/lon coordinates (eg. pasted) as start and end points in the search fields
- Allow map rotation gesture
- Switch input focus to destination point search after selecting a departure suggestion
- Add an indication label in the itinerary list for the entries that have the first leg with real time info
- Add a ticket information card (Fares v2) in itinerary view and ticket badge/icon in itinerary list
& @magdhelena's PR #18
into one for easier merging - all commits / contributions kept in unaltered.