### PR TITLE
Trip view improvements - (clickable stops, refresh times, see full trip) & apply transit options

### DIFF
--- a/lib/models/itinerary.dart
+++ b/lib/models/itinerary.dart
@@ -218,6 +218,26 @@ class Itinerary {
 
   bool get hasTicketInfo => ticketInfo.isNotEmpty;
 
+  /// Returns a copy of this itinerary with [newLegs] substituted in,
+  /// recomputing the fields derived from the leg list (e.g. after a
+  /// real-time refresh updates individual legs).
+  Itinerary withLegs(List<Leg> newLegs) {
+    if (newLegs.isEmpty) return this;
+    final transitLegCount = newLegs.where((l) => l.mode != 'WALK').length;
+    return Itinerary(
+      duration: newLegs.last.endTime
+          .difference(newLegs.first.startTime)
+          .inSeconds,
+      startTime: newLegs.first.startTime,
+      endTime: newLegs.last.endTime,
+      transfers: transitLegCount > 0 ? transitLegCount - 1 : 0,
+      legs: newLegs,
+      isDirect: isDirect,
+      fare: fare,
+      ticketInfo: ticketInfo,
+    );
+  }
+
   double get walkingDistance {
     double totalDistance = 0.0;
     for (final leg in legs) {
@@ -384,6 +404,8 @@ class Leg {
   final String? toTrack;
   final String? fromScheduledTrack;
   final String? toScheduledTrack;
+  final String? fromStopId;
+  final String? toStopId;
   final double fromLat;
   final double fromLon;
   final double toLat;
@@ -423,6 +445,8 @@ class Leg {
     this.toTrack,
     this.fromScheduledTrack,
     this.toScheduledTrack,
+    this.fromStopId,
+    this.toStopId,
     required this.fromLat,
     required this.fromLon,
     required this.toLat,
@@ -434,6 +458,56 @@ class Leg {
     this.fareTransferIndex,
     this.effectiveFareLegIndex,
   });
+
+  /// Returns a copy of this leg with the real-time fields (times, delay,
+  /// cancellation, track, intermediate stops, alerts) refreshed from
+  /// [fresh], while keeping itinerary-specific context (fare indices,
+  /// geometry) from this leg.
+  Leg withRealTimeFrom(Leg fresh) {
+    return Leg(
+      mode: mode,
+      fromName: fromName,
+      toName: toName,
+      startTime: fresh.startTime,
+      endTime: fresh.endTime,
+      scheduledStartTime: fresh.scheduledStartTime ?? scheduledStartTime,
+      scheduledEndTime: fresh.scheduledEndTime ?? scheduledEndTime,
+      duration: fresh.duration,
+      distance: distance,
+      routeShortName: routeShortName,
+      routeLongName: routeLongName,
+      displayName: displayName,
+      headsign: headsign,
+      routeColor: routeColor,
+      routeTextColor: routeTextColor,
+      routeType: routeType,
+      agencyName: agencyName,
+      agencyUrl: agencyUrl,
+      agencyId: agencyId,
+      tripId: tripId,
+      tripShortName: tripShortName,
+      realTime: fresh.realTime,
+      cancelled: fresh.cancelled,
+      fromTrack: fresh.fromTrack ?? fromTrack,
+      toTrack: fresh.toTrack ?? toTrack,
+      fromScheduledTrack: fromScheduledTrack,
+      toScheduledTrack: toScheduledTrack,
+      fromStopId: fromStopId,
+      toStopId: toStopId,
+      fromLat: fromLat,
+      fromLon: fromLon,
+      toLat: toLat,
+      toLon: toLon,
+      intermediateStops: fresh.intermediateStops.isNotEmpty
+          ? fresh.intermediateStops
+          : intermediateStops,
+      alerts: fresh.alerts.isNotEmpty ? fresh.alerts : alerts,
+      legGeometry: legGeometry,
+      interlineWithPreviousLeg: interlineWithPreviousLeg,
+      fareTransferIndex: fareTransferIndex,
+      effectiveFareLegIndex: effectiveFareLegIndex,
+    );
+  }
 
   factory Leg.fromJson(Map<String, dynamic> json) {
     try {
@@ -524,6 +598,8 @@ class Leg {
         toTrack: toMap['track'],
         fromScheduledTrack: fromMap['scheduledTrack'],
         toScheduledTrack: toMap['scheduledTrack'],
+        fromStopId: fromMap['stopId'],
+        toStopId: toMap['stopId'],
         fromLat: fromMap['lat']?.toDouble() ?? 0.0,
         fromLon: fromMap['lon']?.toDouble() ?? 0.0,
         toLat: toMap['lat']?.toDouble() ?? 0.0,

--- a/lib/models/journey_stop.dart
+++ b/lib/models/journey_stop.dart
@@ -3,6 +3,7 @@ import 'itinerary.dart';
 class JourneyStop {
   const JourneyStop({
     required this.name,
+    this.stopId,
     required this.lat,
     required this.lon,
     required this.arrival,
@@ -16,6 +17,7 @@ class JourneyStop {
   });
 
   final String name;
+  final String? stopId;
   final double lat;
   final double lon;
   final DateTime? arrival;

--- a/lib/screens/connection_info_screen.dart
+++ b/lib/screens/connection_info_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/cupertino.dart' show CupertinoSliverRefreshControl;
 import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
@@ -18,8 +19,10 @@ import '../widgets/custom_app_bar.dart';
 import '../widgets/custom_card.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/info_chip.dart';
+import '../widgets/last_updated_footer.dart';
 import '../widgets/skeletons/skeleton_card.dart';
 import '../widgets/skeletons/skeleton_shimmer.dart';
+import '../widgets/stop_departures_sheet.dart';
 import '../widgets/stop_schedule_row.dart';
 import '../widgets/timeline_indicator_box.dart';
 import 'itinerary_map_screen.dart';
@@ -38,6 +41,8 @@ class _ConnectionInfoScreenState extends State<ConnectionInfoScreen> {
   bool _isLoading = true;
   String? _error;
   Timer? _refreshTimer;
+  DateTime? _lastUpdated;
+  bool _isRefreshing = false;
 
   @override
   void initState() {
@@ -59,6 +64,7 @@ class _ConnectionInfoScreenState extends State<ConnectionInfoScreen> {
         setState(() {
           _itinerary = details;
           _isLoading = false;
+          _lastUpdated = DateTime.now();
         });
       }
     } catch (e) {
@@ -69,6 +75,52 @@ class _ConnectionInfoScreenState extends State<ConnectionInfoScreen> {
         });
       }
     }
+  }
+
+  Future<void> _refreshTripDetails() async {
+    if (_isRefreshing) return;
+    _isRefreshing = true;
+    try {
+      final details = await TripDetailsService.fetchTripDetails(
+        tripId: widget.tripId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _itinerary = details;
+        _error = null;
+        _lastUpdated = DateTime.now();
+      });
+    } catch (_) {
+      // Keep showing the previously loaded trip if the refresh fails.
+    } finally {
+      _isRefreshing = false;
+    }
+  }
+
+  void _openStopSheet({
+    required String? stopId,
+    required String stopName,
+    required DateTime referenceTime,
+  }) {
+    if (stopId == null || stopId.isEmpty) return;
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Stop departures',
+      barrierColor: const Color(0x00000000),
+      transitionDuration: const Duration(milliseconds: 180),
+      pageBuilder: (context, _, __) {
+        return StopDeparturesSheet(
+          stopId: stopId,
+          stopName: stopName,
+          referenceTime: referenceTime,
+          onDismiss: () => Navigator.of(context, rootNavigator: true).pop(),
+        );
+      },
+      transitionBuilder: (context, animation, _, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+    );
   }
 
   bool _isSameMinute(DateTime a, DateTime b) {
@@ -270,457 +322,503 @@ class _ConnectionInfoScreenState extends State<ConnectionInfoScreen> {
       }
     }
 
-    return SingleChildScrollView(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          CustomCard(
+    return CustomScrollView(
+      physics: const BouncingScrollPhysics(
+        parent: AlwaysScrollableScrollPhysics(),
+      ),
+      slivers: [
+        CupertinoSliverRefreshControl(onRefresh: _refreshTripDetails),
+        SliverPadding(
+          padding: const EdgeInsets.only(bottom: 16),
+          sliver: SliverToBoxAdapter(
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Row(
-                  children: [
-                    Icon(modeIcon, size: 32, color: AppColors.black),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                CustomCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
                         children: [
-                          if (leg.displayName != null)
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 10,
-                                vertical: 6,
-                              ),
-                              decoration: BoxDecoration(
-                                color: routeColor,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                              child: Text(
-                                leg.displayName!,
-                                style: TextStyle(
-                                  color: routeTextColor,
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w700,
+                          Icon(modeIcon, size: 32, color: AppColors.black),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                if (leg.displayName != null)
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 10,
+                                      vertical: 6,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: routeColor,
+                                      borderRadius: BorderRadius.circular(6),
+                                    ),
+                                    child: Text(
+                                      leg.displayName!,
+                                      style: TextStyle(
+                                        color: routeTextColor,
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    ),
+                                  ),
+                                if (leg.headsign != null) ...[
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    '${getTransitModeName(leg.mode)} • ${leg.headsign!}',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w600,
+                                      color: AppColors.black,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                          GestureDetector(
+                            onTap: () {
+                              Navigator.of(context).push(
+                                CustomPageRoute(
+                                  child: ItineraryMapScreen(
+                                    itinerary: _itinerary!,
+                                    showCarousel: false,
+                                  ),
                                 ),
+                              );
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.all(8),
+                              child: Icon(
+                                LucideIcons.map,
+                                size: 20,
+                                color: AppColors.accentOf(context),
                               ),
                             ),
-                          if (leg.headsign != null) ...[
-                            const SizedBox(height: 8),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+
+                if (allAlerts.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  CustomCard(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
                             Text(
-                              '${getTransitModeName(leg.mode)} • ${leg.headsign!}',
+                              'Warnings',
                               style: TextStyle(
                                 fontSize: 16,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: FontWeight.w700,
                                 color: AppColors.black,
                               ),
                             ),
                           ],
-                        ],
-                      ),
-                    ),
-                    GestureDetector(
-                      onTap: () {
-                        Navigator.of(context).push(
-                          CustomPageRoute(
-                            child: ItineraryMapScreen(
-                              itinerary: _itinerary!,
-                              showCarousel: false,
-                            ),
-                          ),
-                        );
-                      },
-                      child: Container(
-                        padding: const EdgeInsets.all(8),
-                        child: Icon(
-                          LucideIcons.map,
-                          size: 20,
-                          color: AppColors.accentOf(context),
                         ),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
+                        const SizedBox(height: 12),
+                        ...allAlerts.values.map((alert) {
+                          final hasTitle =
+                              alert.headerText != null &&
+                              alert.headerText!.isNotEmpty;
+                          final hasBody =
+                              alert.descriptionText != null &&
+                              alert.descriptionText!.isNotEmpty;
 
-          if (allAlerts.isNotEmpty) ...[
-            const SizedBox(height: 12),
-            CustomCard(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Container(
+                              padding: const EdgeInsets.all(12),
+                              decoration: BoxDecoration(
+                                color: alertBgColor,
+                                borderRadius: BorderRadius.circular(8),
+                                border: Border.all(color: alertBorderColor),
+                              ),
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Icon(
+                                    LucideIcons.triangleAlert,
+                                    size: 16,
+                                    color: alertIconColor,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        if (hasTitle)
+                                          Text(
+                                            alert.headerText!,
+                                            style: TextStyle(
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.bold,
+                                              color: AppColors.black,
+                                            ),
+                                          ),
+                                        if (hasBody) ...[
+                                          if (hasTitle)
+                                            const SizedBox(height: 2),
+                                          Text(
+                                            alert.descriptionText!,
+                                            style: TextStyle(
+                                              fontSize: 13,
+                                              color: AppColors.black.withValues(
+                                                alpha: 0.8,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        }),
+                      ],
+                    ),
+                  ),
+                ],
+
+                const SizedBox(height: 12),
+                CustomCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       Text(
-                        'Warnings',
+                        'Information',
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
                           color: AppColors.black,
                         ),
                       ),
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          if (leg.realTime)
+                            const InfoChip(
+                              icon: LucideIcons.radio,
+                              label: 'Real-time',
+                            ),
+                          if (leg.cancelled == true)
+                            const InfoChip(
+                              icon: LucideIcons.x,
+                              label: 'CANCELLED',
+                              tint: Color(0xFFD32F2F),
+                            ),
+                          InfoChip(
+                            icon: LucideIcons.clock,
+                            label: formatDuration(leg.duration),
+                          ),
+                          if (leg.distance != null)
+                            InfoChip(
+                              icon: LucideIcons.ruler,
+                              label:
+                                  '${(leg.distance! / 1000).toStringAsFixed(1)} km',
+                            ),
+                          if (leg.agencyName != null)
+                            InfoChip(
+                              icon: LucideIcons.building,
+                              label: leg.agencyName!,
+                            ),
+                          if (leg.routeLongName != null &&
+                              leg.routeLongName!.isNotEmpty)
+                            InfoChip(
+                              icon: LucideIcons.route,
+                              label: leg.routeLongName!,
+                            ),
+                        ],
+                      ),
                     ],
                   ),
-                  const SizedBox(height: 12),
-                  ...allAlerts.values.map((alert) {
-                    final hasTitle =
-                        alert.headerText != null &&
-                        alert.headerText!.isNotEmpty;
-                    final hasBody =
-                        alert.descriptionText != null &&
-                        alert.descriptionText!.isNotEmpty;
+                ),
 
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: Container(
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: alertBgColor,
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(color: alertBorderColor),
+                const SizedBox(height: 12),
+                CustomCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Journey',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.black,
                         ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Icon(
-                              LucideIcons.triangleAlert,
-                              size: 16,
-                              color: alertIconColor,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  if (hasTitle)
-                                    Text(
-                                      alert.headerText!,
-                                      style: TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.bold,
-                                        color: AppColors.black,
-                                      ),
+                      ),
+                      const SizedBox(height: 16),
+                      FixedTimeline.tileBuilder(
+                        theme: TimelineThemeData(
+                          nodePosition: 0.08,
+                          color: routeColor,
+                          indicatorTheme: const IndicatorThemeData(size: 28),
+                          connectorTheme: const ConnectorThemeData(
+                            thickness: 2.5,
+                          ),
+                        ),
+                        builder: TimelineTileBuilder.connected(
+                          itemCount: timelineItems.length,
+                          connectionDirection: ConnectionDirection.before,
+                          contentsBuilder: (context, index) {
+                            final item = timelineItems[index];
+
+                            if (item.isVehicle && item.stop == null) {
+                              return const SizedBox.shrink();
+                            }
+
+                            final stop = item.stop!;
+                            final stopIndex = stops.indexOf(stop);
+                            final isPassed = stopIndex <= currentStopIndex;
+                            final isUpcoming = stopIndex == upcomingStopIndex;
+
+                            final arrRow = buildStopScheduleRow(
+                              'Arr',
+                              stop.scheduledArrival,
+                              stop.arrival,
+                              isPassed,
+                            );
+                            final depRow = buildStopScheduleRow(
+                              'Dep',
+                              stop.scheduledDeparture,
+                              stop.departure,
+                              isPassed,
+                            );
+
+                            return GestureDetector(
+                              onTap: stop.stopId == null
+                                  ? null
+                                  : () => _openStopSheet(
+                                      stopId: stop.stopId,
+                                      stopName: stop.name,
+                                      referenceTime:
+                                          stop.departure ??
+                                          stop.arrival ??
+                                          DateTime.now().toUtc(),
                                     ),
-                                  if (hasBody) ...[
-                                    if (hasTitle) const SizedBox(height: 2),
-                                    Text(
-                                      alert.descriptionText!,
-                                      style: TextStyle(
-                                        fontSize: 13,
-                                        color: AppColors.black.withValues(
-                                          alpha: 0.8,
+                              child: Padding(
+                                padding: const EdgeInsets.only(
+                                  left: 12,
+                                  bottom: 16,
+                                ),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            stop.name,
+                                            style: TextStyle(
+                                              fontSize: 14,
+                                              fontWeight:
+                                                  stopIndex == 0 ||
+                                                      stopIndex ==
+                                                          stops.length - 1 ||
+                                                      isUpcoming
+                                                  ? FontWeight.w600
+                                                  : FontWeight.normal,
+                                              color: isPassed
+                                                  ? AppColors.black.withValues(
+                                                      alpha: 0.5,
+                                                    )
+                                                  : AppColors.black,
+                                            ),
+                                          ),
                                         ),
+                                        if (isUpcoming) ...[
+                                          const SizedBox(width: 8),
+                                          Container(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 6,
+                                              vertical: 2,
+                                            ),
+                                            decoration: BoxDecoration(
+                                              color: routeColor.withValues(
+                                                alpha: 0.2,
+                                              ),
+                                              borderRadius:
+                                                  BorderRadius.circular(4),
+                                            ),
+                                            child: Text(
+                                              'Upcoming',
+                                              style: TextStyle(
+                                                fontSize: 11,
+                                                fontWeight: FontWeight.w700,
+                                                color: routeColor,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                    if (arrRow != null || depRow != null) ...[
+                                      const SizedBox(height: 2),
+                                      if (arrRow != null) arrRow,
+                                      if (depRow != null) ...[
+                                        if (arrRow != null)
+                                          const SizedBox(height: 2),
+                                        depRow,
+                                      ],
+                                    ],
+                                    if (stop.track != null) ...[
+                                      const SizedBox(height: 2),
+                                      Text(
+                                        'Track ${stop.track}',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: isPassed
+                                              ? AppColors.black.withValues(
+                                                  alpha: 0.4,
+                                                )
+                                              : AppColors.black.withValues(
+                                                  alpha: 0.5,
+                                                ),
+                                        ),
+                                      ),
+                                    ],
+                                    if (stop.cancelled == true) ...[
+                                      const SizedBox(height: 2),
+                                      const Text(
+                                        'CANCELLED',
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          color: Color(0xFFD32F2F),
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                          indicatorBuilder: (context, index) {
+                            final item = timelineItems[index];
+
+                            if (item.isVehicle && item.stop == null) {
+                              return TimelineIndicatorBox(
+                                lineColor: routeColor,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: routeColor,
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: Center(
+                                    child: Icon(
+                                      modeIcon,
+                                      size: 14,
+                                      color: routeTextColor,
+                                    ),
+                                  ),
+                                ),
+                              );
+                            }
+
+                            final stop = item.stop!;
+                            final stopIndex = stops.indexOf(stop);
+                            final isPassed = stopIndex <= currentStopIndex;
+
+                            final bool isTerminal =
+                                stopIndex == 0 || stopIndex == stops.length - 1;
+                            final double dotSize = isTerminal ? 16 : 12;
+                            final Color dotColor = isPassed
+                                ? routeColor.withValues(alpha: 0.6)
+                                : routeColor;
+
+                            final bool isVehicleHere =
+                                showVehicle &&
+                                isVehicleAtStation &&
+                                stopIndex == vehicleStopIndex;
+                            final bool isFirstStop = stopIndex == 0;
+                            final bool isLastStop =
+                                stopIndex == stops.length - 1;
+
+                            if (isVehicleHere) {
+                              return TimelineIndicatorBox(
+                                lineColor: dotColor,
+                                centerGap: 28.0,
+                                cutTop: isFirstStop,
+                                cutBottom: isLastStop,
+                                child: Stack(
+                                  alignment: Alignment.center,
+                                  children: [
+                                    DotIndicator(
+                                      color: dotColor,
+                                      size: dotSize,
+                                    ),
+                                    Container(
+                                      width: 28,
+                                      height: 28,
+                                      decoration: BoxDecoration(
+                                        color: routeColor,
+                                        shape: BoxShape.circle,
+                                      ),
+                                      child: Icon(
+                                        modeIcon,
+                                        size: 14,
+                                        color: routeTextColor,
                                       ),
                                     ),
                                   ],
-                                ],
+                                ),
+                              );
+                            }
+
+                            return TimelineIndicatorBox(
+                              lineColor: dotColor,
+                              centerGap: (dotSize),
+                              cutTop: isFirstStop,
+                              cutBottom: isLastStop,
+                              child: Center(
+                                child: DotIndicator(
+                                  color: dotColor,
+                                  size: dotSize,
+                                ),
                               ),
-                            ),
-                          ],
+                            );
+                          },
+                          connectorBuilder: (context, index, connectorType) {
+                            bool isPassed = false;
+                            if (index < timelineItems.length) {
+                              final item = timelineItems[index];
+                              if (item.isVehicle) {
+                                isPassed = true;
+                              } else {
+                                final stopIndex = stops.indexOf(item.stop!);
+                                isPassed = stopIndex <= currentStopIndex;
+                              }
+                            }
+
+                            return SolidLineConnector(
+                              color: isPassed
+                                  ? routeColor.withValues(alpha: 0.6)
+                                  : routeColor,
+                            );
+                          },
                         ),
                       ),
-                    );
-                  }),
-                ],
-              ),
-            ),
-          ],
-
-          const SizedBox(height: 12),
-          CustomCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Text(
-                  'Information',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.black,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    if (leg.realTime)
-                      const InfoChip(
-                        icon: LucideIcons.radio,
-                        label: 'Real-time',
-                      ),
-                    if (leg.cancelled == true)
-                      const InfoChip(
-                        icon: LucideIcons.x,
-                        label: 'CANCELLED',
-                        tint: Color(0xFFD32F2F),
-                      ),
-                    InfoChip(
-                      icon: LucideIcons.clock,
-                      label: formatDuration(leg.duration),
-                    ),
-                    if (leg.distance != null)
-                      InfoChip(
-                        icon: LucideIcons.ruler,
-                        label:
-                            '${(leg.distance! / 1000).toStringAsFixed(1)} km',
-                      ),
-                    if (leg.agencyName != null)
-                      InfoChip(
-                        icon: LucideIcons.building,
-                        label: leg.agencyName!,
-                      ),
-                    if (leg.routeLongName != null &&
-                        leg.routeLongName!.isNotEmpty)
-                      InfoChip(
-                        icon: LucideIcons.route,
-                        label: leg.routeLongName!,
-                      ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-
-          const SizedBox(height: 12),
-          CustomCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Journey',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.black,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                FixedTimeline.tileBuilder(
-                  theme: TimelineThemeData(
-                    nodePosition: 0.08,
-                    color: routeColor,
-                    indicatorTheme: const IndicatorThemeData(size: 28),
-                    connectorTheme: const ConnectorThemeData(thickness: 2.5),
-                  ),
-                  builder: TimelineTileBuilder.connected(
-                    itemCount: timelineItems.length,
-                    connectionDirection: ConnectionDirection.before,
-                    contentsBuilder: (context, index) {
-                      final item = timelineItems[index];
-
-                      if (item.isVehicle && item.stop == null) {
-                        return const SizedBox.shrink();
-                      }
-
-                      final stop = item.stop!;
-                      final stopIndex = stops.indexOf(stop);
-                      final isPassed = stopIndex <= currentStopIndex;
-                      final isUpcoming = stopIndex == upcomingStopIndex;
-
-                      final arrRow = buildStopScheduleRow(
-                        'Arr',
-                        stop.scheduledArrival,
-                        stop.arrival,
-                        isPassed,
-                      );
-                      final depRow = buildStopScheduleRow(
-                        'Dep',
-                        stop.scheduledDeparture,
-                        stop.departure,
-                        isPassed,
-                      );
-
-                      return Padding(
-                        padding: const EdgeInsets.only(left: 12, bottom: 16),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    stop.name,
-                                    style: TextStyle(
-                                      fontSize: 14,
-                                      fontWeight:
-                                          stopIndex == 0 ||
-                                              stopIndex == stops.length - 1 ||
-                                              isUpcoming
-                                          ? FontWeight.w600
-                                          : FontWeight.normal,
-                                      color: isPassed
-                                          ? AppColors.black.withValues(
-                                              alpha: 0.5,
-                                            )
-                                          : AppColors.black,
-                                    ),
-                                  ),
-                                ),
-                                if (isUpcoming) ...[
-                                  const SizedBox(width: 8),
-                                  Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 6,
-                                      vertical: 2,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: routeColor.withValues(alpha: 0.2),
-                                      borderRadius: BorderRadius.circular(4),
-                                    ),
-                                    child: Text(
-                                      'Upcoming',
-                                      style: TextStyle(
-                                        fontSize: 11,
-                                        fontWeight: FontWeight.w700,
-                                        color: routeColor,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ],
-                            ),
-                            if (arrRow != null || depRow != null) ...[
-                              const SizedBox(height: 2),
-                              if (arrRow != null) arrRow,
-                              if (depRow != null) ...[
-                                if (arrRow != null) const SizedBox(height: 2),
-                                depRow,
-                              ],
-                            ],
-                            if (stop.track != null) ...[
-                              const SizedBox(height: 2),
-                              Text(
-                                'Track ${stop.track}',
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: isPassed
-                                      ? AppColors.black.withValues(alpha: 0.4)
-                                      : AppColors.black.withValues(alpha: 0.5),
-                                ),
-                              ),
-                            ],
-                            if (stop.cancelled == true) ...[
-                              const SizedBox(height: 2),
-                              const Text(
-                                'CANCELLED',
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: Color(0xFFD32F2F),
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            ],
-                          ],
-                        ),
-                      );
-                    },
-                    indicatorBuilder: (context, index) {
-                      final item = timelineItems[index];
-
-                      if (item.isVehicle && item.stop == null) {
-                        return TimelineIndicatorBox(
-                          lineColor: routeColor,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              color: routeColor,
-                              shape: BoxShape.circle,
-                            ),
-                            child: Center(
-                              child: Icon(
-                                modeIcon,
-                                size: 14,
-                                color: routeTextColor,
-                              ),
-                            ),
-                          ),
-                        );
-                      }
-
-                      final stop = item.stop!;
-                      final stopIndex = stops.indexOf(stop);
-                      final isPassed = stopIndex <= currentStopIndex;
-
-                      final bool isTerminal =
-                          stopIndex == 0 || stopIndex == stops.length - 1;
-                      final double dotSize = isTerminal ? 16 : 12;
-                      final Color dotColor = isPassed
-                          ? routeColor.withValues(alpha: 0.6)
-                          : routeColor;
-
-                      final bool isVehicleHere =
-                          showVehicle &&
-                          isVehicleAtStation &&
-                          stopIndex == vehicleStopIndex;
-                      final bool isFirstStop = stopIndex == 0;
-                      final bool isLastStop = stopIndex == stops.length - 1;
-
-                      if (isVehicleHere) {
-                        return TimelineIndicatorBox(
-                          lineColor: dotColor,
-                          centerGap: 28.0,
-                          cutTop: isFirstStop,
-                          cutBottom: isLastStop,
-                          child: Stack(
-                            alignment: Alignment.center,
-                            children: [
-                              DotIndicator(color: dotColor, size: dotSize),
-                              Container(
-                                width: 28,
-                                height: 28,
-                                decoration: BoxDecoration(
-                                  color: routeColor,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: Icon(
-                                  modeIcon,
-                                  size: 14,
-                                  color: routeTextColor,
-                                ),
-                              ),
-                            ],
-                          ),
-                        );
-                      }
-
-                      return TimelineIndicatorBox(
-                        lineColor: dotColor,
-                        centerGap: (dotSize),
-                        cutTop: isFirstStop,
-                        cutBottom: isLastStop,
-                        child: Center(
-                          child: DotIndicator(color: dotColor, size: dotSize),
-                        ),
-                      );
-                    },
-                    connectorBuilder: (context, index, connectorType) {
-                      bool isPassed = false;
-                      if (index < timelineItems.length) {
-                        final item = timelineItems[index];
-                        if (item.isVehicle) {
-                          isPassed = true;
-                        } else {
-                          final stopIndex = stops.indexOf(item.stop!);
-                          isPassed = stopIndex <= currentStopIndex;
-                        }
-                      }
-
-                      return SolidLineConnector(
-                        color: isPassed
-                            ? routeColor.withValues(alpha: 0.6)
-                            : routeColor,
-                      );
-                    },
+                    ],
                   ),
                 ),
               ],
             ),
           ),
-        ],
-      ),
+        ),
+        SliverToBoxAdapter(child: LastUpdatedFooter(lastUpdated: _lastUpdated)),
+      ],
     );
   }
 

--- a/lib/screens/itinerary_detail_screen.dart
+++ b/lib/screens/itinerary_detail_screen.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:transportia/widgets/load_more_button.dart';
+import 'package:flutter/cupertino.dart' show CupertinoSliverRefreshControl;
 import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:provider/provider.dart';
@@ -9,6 +11,7 @@ import 'package:timelines_plus/timelines_plus.dart';
 
 import '../models/itinerary.dart';
 import '../providers/theme_provider.dart';
+import '../services/trip_details_service.dart';
 import '../theme/app_colors.dart';
 import '../utils/color_utils.dart';
 import '../utils/custom_page_route.dart';
@@ -19,7 +22,19 @@ import '../utils/time_utils.dart';
 import '../widgets/custom_app_bar.dart';
 import '../widgets/custom_card.dart';
 import '../widgets/info_chip.dart';
+import '../widgets/last_updated_footer.dart';
+import '../widgets/stop_departures_sheet.dart';
+import 'connection_info_screen.dart';
 import 'itinerary_map_screen.dart';
+
+/// Opens the [StopDeparturesSheet] for a tapped stop. Passed down through
+/// the leg widgets so they don't need to know how the sheet is presented.
+typedef OpenStopSheet =
+    void Function({
+      required String? stopId,
+      required String stopName,
+      required DateTime referenceTime,
+    });
 
 class ItineraryDetailScreen extends StatefulWidget {
   final Itinerary itinerary;
@@ -32,11 +47,105 @@ class ItineraryDetailScreen extends StatefulWidget {
 
 class _ItineraryDetailScreenState extends State<ItineraryDetailScreen> {
   bool _isSharing = false;
+  late Itinerary _itinerary;
+  DateTime? _lastUpdated;
+  bool _isRefreshing = false;
+  Timer? _agoTicker;
+
+  @override
+  void initState() {
+    super.initState();
+    _itinerary = widget.itinerary;
+    _lastUpdated = DateTime.now();
+    _agoTicker = Timer.periodic(const Duration(seconds: 30), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _agoTicker?.cancel();
+    super.dispose();
+  }
+
+  void _openStopSheet({
+    required String? stopId,
+    required String stopName,
+    required DateTime referenceTime,
+  }) {
+    if (stopId == null || stopId.isEmpty) return;
+
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Stop departures',
+      barrierColor: const Color(0x00000000),
+      transitionDuration: const Duration(milliseconds: 180),
+      pageBuilder: (context, _, __) {
+        return StopDeparturesSheet(
+          stopId: stopId,
+          stopName: stopName,
+          referenceTime: referenceTime,
+          onDismiss: () => Navigator.of(context, rootNavigator: true).pop(),
+        );
+      },
+      transitionBuilder: (context, animation, _, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+    );
+  }
+
+  Future<void> _refreshRealTimeInfo() async {
+    if (_isRefreshing) return;
+
+    final tripIds = _itinerary.legs
+        .map((leg) => leg.tripId)
+        .whereType<String>()
+        .where((id) => id.isNotEmpty)
+        .toSet();
+
+    if (tripIds.isEmpty) return;
+
+    _isRefreshing = true;
+    final updates = <String, Leg>{};
+    await Future.wait(
+      tripIds.map((tripId) async {
+        try {
+          final details = await TripDetailsService.fetchTripDetails(
+            tripId: tripId,
+          );
+          if (details.legs.isNotEmpty) {
+            updates[tripId] = details.legs.first;
+          }
+        } catch (_) {}
+      }),
+    );
+
+    if (!mounted) {
+      _isRefreshing = false;
+      return;
+    }
+
+    if (updates.isNotEmpty) {
+      final newLegs = _itinerary.legs.map((leg) {
+        final fresh = leg.tripId != null ? updates[leg.tripId] : null;
+        return fresh != null ? leg.withRealTimeFrom(fresh) : leg;
+      }).toList();
+      setState(() {
+        _itinerary = _itinerary.withLegs(newLegs);
+        _lastUpdated = DateTime.now();
+      });
+    } else {
+      setState(() => _lastUpdated = DateTime.now());
+    }
+
+    _isRefreshing = false;
+  }
 
   @override
   Widget build(BuildContext context) {
     context.watch<ThemeProvider>();
-    final displayLegs = buildDisplayLegs(widget.itinerary.legs);
+    final displayLegs = buildDisplayLegs(_itinerary.legs);
 
     return Container(
       color: AppColors.white,
@@ -48,13 +157,13 @@ class _ItineraryDetailScreenState extends State<ItineraryDetailScreen> {
               title: 'Itinerary Details',
               onBackButtonPressed: () => Navigator.of(context).pop(),
             ),
-            JourneyOverviewWidget(itinerary: widget.itinerary),
+            JourneyOverviewWidget(itinerary: _itinerary),
             Expanded(
               child: Builder(
                 builder: (context) {
-                  final hasTicketInfo = widget.itinerary.hasTicketInfo;
+                  final hasTicketInfo = _itinerary.hasTicketInfo;
                   final ticketInsertIndex = hasTicketInfo ? 1 : 0;
-                  final hasFinishCard = widget.itinerary.legs.isNotEmpty;
+                  final hasFinishCard = _itinerary.legs.isNotEmpty;
                   final legsInsertIndex = ticketInsertIndex;
                   final emptyMessageIndex = displayLegs.isEmpty
                       ? legsInsertIndex
@@ -65,61 +174,93 @@ class _ItineraryDetailScreenState extends State<ItineraryDetailScreen> {
                   final finishInsertIndex = legsEndIndex;
                   final shareIndex =
                       finishInsertIndex + (hasFinishCard ? 1 : 0);
-                  final totalItems = shareIndex + 1;
+                  final footerIndex = shareIndex + 1;
+                  final totalItems = footerIndex + 1;
 
-                  return ListView.builder(
-                    padding: const EdgeInsets.only(bottom: 16),
-                    itemCount: totalItems,
-                    itemBuilder: (context, index) {
-                      if (hasTicketInfo && index == 0) {
-                        return TicketInfoCard(
-                          ticketInfo: widget.itinerary.ticketInfo,
-                        );
-                      }
+                  return CustomScrollView(
+                    physics: const BouncingScrollPhysics(
+                      parent: AlwaysScrollableScrollPhysics(),
+                    ),
+                    slivers: [
+                      CupertinoSliverRefreshControl(
+                        onRefresh: _refreshRealTimeInfo,
+                      ),
+                      SliverPadding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        sliver: SliverList(
+                          delegate: SliverChildBuilderDelegate((
+                            context,
+                            index,
+                          ) {
+                            if (hasTicketInfo && index == 0) {
+                              return TicketInfoCard(
+                                ticketInfo: _itinerary.ticketInfo,
+                              );
+                            }
 
-                      if (index == emptyMessageIndex) {
-                        return Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Center(
-                            child: Text(
-                              'No additional steps required for this journey.',
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: AppColors.black.withValues(alpha: 0.4),
-                              ),
-                            ),
-                          ),
-                        );
-                      }
+                            if (index == emptyMessageIndex) {
+                              return Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Center(
+                                  child: Text(
+                                    'No additional steps required for this journey.',
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      color: AppColors.black.withValues(
+                                        alpha: 0.4,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            }
 
-                      if (index >= legsInsertIndex && index < legsEndIndex) {
-                        final entry = displayLegs[index - legsInsertIndex];
-                        if (entry.isTransfer) {
-                          return TransferLegCard(leg: entry.leg);
-                        }
-                        return LegDetailsWidget(leg: entry.leg);
-                      }
+                            if (index >= legsInsertIndex &&
+                                index < legsEndIndex) {
+                              final entry =
+                                  displayLegs[index - legsInsertIndex];
+                              if (entry.isTransfer) {
+                                return TransferLegCard(
+                                  leg: entry.leg,
+                                  openStopSheet: _openStopSheet,
+                                );
+                              }
+                              return LegDetailsWidget(
+                                leg: entry.leg,
+                                openStopSheet: _openStopSheet,
+                              );
+                            }
 
-                      if (hasFinishCard && index == finishInsertIndex) {
-                        final finishLeg = widget.itinerary.legs.last;
-                        return FinishLegCard(
-                          leg: finishLeg,
-                          arrivalTime: widget.itinerary.endTime,
-                          totalDuration: widget.itinerary.duration,
-                        );
-                      }
+                            if (hasFinishCard && index == finishInsertIndex) {
+                              final finishLeg = _itinerary.legs.last;
+                              return FinishLegCard(
+                                leg: finishLeg,
+                                arrivalTime: _itinerary.endTime,
+                                totalDuration: _itinerary.duration,
+                                openStopSheet: _openStopSheet,
+                              );
+                            }
 
-                      if (index == shareIndex) {
-                        return LoadMoreButton(
-                          onTap: _shareItinerary,
-                          isLoading: _isSharing,
-                          label: 'Share this trip',
-                          icon: LucideIcons.share2,
-                        );
-                      }
+                            if (index == shareIndex) {
+                              return LoadMoreButton(
+                                onTap: _shareItinerary,
+                                isLoading: _isSharing,
+                                label: 'Share this trip',
+                                icon: LucideIcons.share2,
+                              );
+                            }
 
-                      return const SizedBox.shrink();
-                    },
+                            if (index == footerIndex) {
+                              return LastUpdatedFooter(
+                                lastUpdated: _lastUpdated,
+                              );
+                            }
+
+                            return const SizedBox.shrink();
+                          }, childCount: totalItems),
+                        ),
+                      ),
+                    ],
                   );
                 },
               ),
@@ -133,7 +274,7 @@ class _ItineraryDetailScreenState extends State<ItineraryDetailScreen> {
   Future<void> _shareItinerary() async {
     if (_isSharing) return;
 
-    final legs = widget.itinerary.legs;
+    final legs = _itinerary.legs;
     if (legs.isEmpty) {
       debugPrint('Cannot share itinerary without any legs.');
       return;
@@ -148,7 +289,7 @@ class _ItineraryDetailScreenState extends State<ItineraryDetailScreen> {
       final payload = jsonEncode({
         'from': {'lat': firstLeg.fromLat, 'lon': firstLeg.fromLon},
         'to': {'lat': lastLeg.toLat, 'lon': lastLeg.toLon},
-        'time': widget.itinerary.startTime.toIso8601String(),
+        'time': _itinerary.startTime.toIso8601String(),
       });
 
       final encoded = base64Url.encode(utf8.encode(payload));
@@ -486,8 +627,13 @@ class _TicketInfoCardState extends State<TicketInfoCard> {
 
 class LegDetailsWidget extends StatefulWidget {
   final Leg leg;
+  final OpenStopSheet openStopSheet;
 
-  const LegDetailsWidget({super.key, required this.leg});
+  const LegDetailsWidget({
+    super.key,
+    required this.leg,
+    required this.openStopSheet,
+  });
 
   @override
   State<LegDetailsWidget> createState() => _LegDetailsWidgetState();
@@ -569,44 +715,58 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
 
             if (!_isExpanded) ...[
               const SizedBox(height: 8),
-              Row(
-                children: [
-                  const Icon(LucideIcons.arrowRight, size: 16),
-                  const SizedBox(width: 4),
-                  Expanded(
-                    child: Text(
-                      '${formatTime(scheduledStart)} - ${widget.leg.fromName}',
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: AppColors.black.withValues(alpha: 0.5),
+              GestureDetector(
+                onTap: () => widget.openStopSheet(
+                  stopId: widget.leg.fromStopId,
+                  stopName: widget.leg.fromName,
+                  referenceTime: widget.leg.startTime,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(LucideIcons.arrowRight, size: 16),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        '${formatTime(scheduledStart)} - ${widget.leg.fromName}',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: AppColors.black.withValues(alpha: 0.5),
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
                     ),
-                  ),
-                  if (departureDelay != null)
-                    _DelayChip(label: formatDelay(departureDelay)),
-                ],
+                    if (departureDelay != null)
+                      _DelayChip(label: formatDelay(departureDelay)),
+                  ],
+                ),
               ),
               const SizedBox(height: 4),
-              Row(
-                children: [
-                  const Icon(LucideIcons.arrowDown, size: 16),
-                  const SizedBox(width: 4),
-                  Expanded(
-                    child: Text(
-                      '${formatTime(scheduledEnd)} - ${widget.leg.toName}',
-                      style: TextStyle(
-                        fontSize: 14,
-                        color: AppColors.black.withValues(alpha: 0.5),
+              GestureDetector(
+                onTap: () => widget.openStopSheet(
+                  stopId: widget.leg.toStopId,
+                  stopName: widget.leg.toName,
+                  referenceTime: widget.leg.endTime,
+                ),
+                child: Row(
+                  children: [
+                    const Icon(LucideIcons.arrowDown, size: 16),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        '${formatTime(scheduledEnd)} - ${widget.leg.toName}',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: AppColors.black.withValues(alpha: 0.5),
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 1,
                       ),
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
                     ),
-                  ),
-                  if (arrivalDelay != null)
-                    _DelayChip(label: formatDelay(arrivalDelay)),
-                ],
+                    if (arrivalDelay != null)
+                      _DelayChip(label: formatDelay(arrivalDelay)),
+                  ],
+                ),
               ),
             ],
 
@@ -652,6 +812,7 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
     stops.add(
       _TimelineStop(
         name: widget.leg.fromName,
+        stopId: widget.leg.fromStopId,
         time: widget.leg.startTime,
         track: widget.leg.fromTrack,
         scheduledTime: widget.leg.scheduledStartTime,
@@ -665,6 +826,7 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
       stops.add(
         _TimelineStop(
           name: stop.name,
+          stopId: stop.stopId,
           time: stop.arrival ?? stop.departure,
           track: stop.track,
           scheduledTime: stop.scheduledArrival ?? stop.scheduledDeparture,
@@ -678,6 +840,7 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
     stops.add(
       _TimelineStop(
         name: widget.leg.toName,
+        stopId: widget.leg.toStopId,
         time: widget.leg.endTime,
         track: widget.leg.toTrack,
         scheduledTime: widget.leg.scheduledEndTime,
@@ -714,7 +877,16 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
               final stop = stops[index];
               return Padding(
                 padding: const EdgeInsets.only(left: 12, bottom: 16),
-                child: _buildStopInfo(stop),
+                child: GestureDetector(
+                  onTap: stop.stopId == null
+                      ? null
+                      : () => widget.openStopSheet(
+                          stopId: stop.stopId,
+                          stopName: stop.name,
+                          referenceTime: stop.time ?? widget.leg.startTime,
+                        ),
+                  child: _buildStopInfo(stop),
+                ),
               );
             },
             indicatorBuilder: (context, index) {
@@ -962,7 +1134,7 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
           (routeColor == null && !isWalkLeg
               ? AppColors.solidWhite
               : AppColors.black);
-      return Align(
+      final badge = Align(
         alignment: Alignment.centerLeft,
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -984,6 +1156,16 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
           ),
         ),
       );
+      final tripId = widget.leg.tripId;
+      if (isWalkLeg || tripId == null || tripId.isEmpty) return badge;
+      return GestureDetector(
+        onTap: () {
+          Navigator.of(
+            context,
+          ).push(CustomPageRoute(child: ConnectionInfoScreen(tripId: tripId)));
+        },
+        child: badge,
+      );
     }
     return Text(
       getTransitModeName(widget.leg.mode),
@@ -1000,8 +1182,13 @@ class _LegDetailsWidgetState extends State<LegDetailsWidget> {
 
 class TransferLegCard extends StatelessWidget {
   final Leg leg;
+  final OpenStopSheet openStopSheet;
 
-  const TransferLegCard({super.key, required this.leg});
+  const TransferLegCard({
+    super.key,
+    required this.leg,
+    required this.openStopSheet,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1033,22 +1220,29 @@ class TransferLegCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 8),
-          Row(
-            children: [
-              const Icon(LucideIcons.arrowRight, size: 16),
-              const SizedBox(width: 4),
-              Expanded(
-                child: Text(
-                  '${formatTime(leg.startTime)} - ${leg.fromName}',
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: AppColors.black.withValues(alpha: 0.5),
+          GestureDetector(
+            onTap: () => openStopSheet(
+              stopId: leg.fromStopId,
+              stopName: leg.fromName,
+              referenceTime: leg.startTime,
+            ),
+            child: Row(
+              children: [
+                const Icon(LucideIcons.arrowRight, size: 16),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    '${formatTime(leg.startTime)} - ${leg.fromName}',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: AppColors.black.withValues(alpha: 0.5),
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
                   ),
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
           if (leg.distance != null && leg.distance! > 0) ...[
             const SizedBox(height: 4),
@@ -1098,44 +1292,53 @@ class FinishLegCard extends StatelessWidget {
   final Leg leg;
   final DateTime arrivalTime;
   final int totalDuration;
+  final OpenStopSheet openStopSheet;
 
   const FinishLegCard({
     super.key,
     required this.leg,
     required this.arrivalTime,
     required this.totalDuration,
+    required this.openStopSheet,
   });
 
   @override
   Widget build(BuildContext context) {
-    return CustomCard(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              const Icon(LucideIcons.flag, size: 20),
-              const SizedBox(width: 8),
-              Text(
-                'Finish',
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.black,
+    return GestureDetector(
+      onTap: () => openStopSheet(
+        stopId: leg.toStopId,
+        stopName: leg.toName,
+        referenceTime: leg.endTime,
+      ),
+      child: CustomCard(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(LucideIcons.flag, size: 20),
+                const SizedBox(width: 8),
+                Text(
+                  'Finish',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.black,
+                  ),
                 ),
-              ),
-              const Spacer(),
-              Text(
-                formatTime(arrivalTime),
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.black,
+                const Spacer(),
+                Text(
+                  formatTime(arrivalTime),
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.black,
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -1143,6 +1346,7 @@ class FinishLegCard extends StatelessWidget {
 
 class _TimelineStop {
   final String name;
+  final String? stopId;
   final DateTime? time;
   final String? track;
   final DateTime? scheduledTime;
@@ -1152,6 +1356,7 @@ class _TimelineStop {
 
   _TimelineStop({
     required this.name,
+    this.stopId,
     this.time,
     this.track,
     this.scheduledTime,

--- a/lib/screens/itinerary_map_screen.dart
+++ b/lib/screens/itinerary_map_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -16,6 +17,7 @@ import '../utils/map_marker_utils.dart';
 import '../utils/polyline_utils.dart';
 import '../utils/time_utils.dart';
 import '../widgets/custom_app_bar.dart';
+import '../widgets/stop_departures_sheet.dart';
 
 class ItineraryMapScreen extends StatefulWidget {
   final Itinerary itinerary;
@@ -39,6 +41,8 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
   bool _didAddStopsLayer = false;
   Future<void>? _stopsLayerInit;
   bool _isMapReady = false;
+  final Map<String, _RouteStop> _stopsById = {};
+  _RouteStop? _selectedStopPopup;
   late final PageController _pageController;
   int _currentPage = 0;
   List<List<LatLng>> _legGeometries = [];
@@ -88,6 +92,7 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
 
   @override
   void dispose() {
+    _controller?.onFeatureTapped.remove(_handleFeatureTapped);
     _pageController.dispose();
     super.dispose();
   }
@@ -126,6 +131,18 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
                 right: 0,
                 bottom: 24,
                 child: _buildJourneyCarousel(),
+              ),
+            if (_selectedStopPopup != null)
+              Positioned(
+                left: 16,
+                right: 16,
+                top: 76,
+                child: _StopInfoPopup(
+                  stop: _selectedStopPopup!,
+                  onDismiss: () => setState(() => _selectedStopPopup = null),
+                  onSeeDepartures: () =>
+                      _openStopDeparturesSheet(_selectedStopPopup!),
+                ),
               ),
           ],
         ),
@@ -306,6 +323,45 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
 
   void _onMapCreated(MapLibreMapController controller) {
     _controller = controller;
+    controller.onFeatureTapped.add(_handleFeatureTapped);
+  }
+
+  void _handleFeatureTapped(
+    math.Point<double> point,
+    LatLng coordinate,
+    String id,
+    String layerId,
+    Annotation? annotation,
+  ) {
+    if (layerId != _kStopsLayerId) return;
+    final stop = _stopsById[id];
+    if (stop == null) return;
+    setState(() => _selectedStopPopup = stop);
+  }
+
+  void _openStopDeparturesSheet(_RouteStop stop) {
+    final referenceTime =
+        stop.departure ?? stop.arrival ?? DateTime.now().toUtc();
+    setState(() => _selectedStopPopup = null);
+
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Stop departures',
+      barrierColor: const Color(0x00000000),
+      transitionDuration: const Duration(milliseconds: 180),
+      pageBuilder: (context, _, __) {
+        return StopDeparturesSheet(
+          stopId: stop.stopId,
+          stopName: stop.name?.isNotEmpty == true ? stop.name! : 'Stop',
+          referenceTime: referenceTime,
+          onDismiss: () => Navigator.of(context, rootNavigator: true).pop(),
+        );
+      },
+      transitionBuilder: (context, animation, _, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+    );
   }
 
   Future<void> _onStyleLoaded() async {
@@ -387,6 +443,12 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
       Color color,
       bool isWalk, {
       bool isTransfer = false,
+      String? name,
+      String? stopId,
+      DateTime? arrival,
+      DateTime? departure,
+      DateTime? scheduledArrival,
+      DateTime? scheduledDeparture,
     }) {
       final key = '${lat.toStringAsFixed(5)},${lon.toStringAsFixed(5)}';
       final existing = deduped[key];
@@ -397,28 +459,28 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
           order: order++,
           isWalk: isWalk,
           isTransfer: isTransfer,
+          name: name,
+          stopId: stopId,
+          arrival: arrival,
+          departure: departure,
+          scheduledArrival: scheduledArrival,
+          scheduledDeparture: scheduledDeparture,
         );
         return;
       }
-      if (existing.isWalk && !isWalk) {
-        deduped[key] = _RouteStop(
-          point: existing.point,
-          color: color,
-          order: existing.order,
-          isWalk: false,
-          isTransfer: existing.isTransfer || isTransfer,
-        );
-        return;
-      }
-      if (!existing.isTransfer && isTransfer) {
-        deduped[key] = _RouteStop(
-          point: existing.point,
-          color: existing.color,
-          order: existing.order,
-          isWalk: existing.isWalk,
-          isTransfer: true,
-        );
-      }
+      deduped[key] = _RouteStop(
+        point: existing.point,
+        color: existing.isWalk && !isWalk ? color : existing.color,
+        order: existing.order,
+        isWalk: existing.isWalk && isWalk,
+        isTransfer: existing.isTransfer || isTransfer,
+        name: existing.name ?? name,
+        stopId: existing.stopId ?? stopId,
+        arrival: existing.arrival ?? arrival,
+        departure: existing.departure ?? departure,
+        scheduledArrival: existing.scheduledArrival ?? scheduledArrival,
+        scheduledDeparture: existing.scheduledDeparture ?? scheduledDeparture,
+      );
     }
 
     for (final entry in _mapLegs) {
@@ -431,6 +493,10 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
         color,
         isWalk,
         isTransfer: entry.isTransfer,
+        name: leg.fromName,
+        stopId: leg.fromStopId,
+        departure: leg.startTime,
+        scheduledDeparture: leg.scheduledStartTime,
       );
       for (final stop in leg.intermediateStops) {
         addStop(
@@ -439,6 +505,12 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
           color,
           isWalk,
           isTransfer: entry.isTransfer,
+          name: stop.name,
+          stopId: stop.stopId,
+          arrival: stop.arrival,
+          departure: stop.departure,
+          scheduledArrival: stop.scheduledArrival,
+          scheduledDeparture: stop.scheduledDeparture,
         );
       }
       addStop(
@@ -447,6 +519,10 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
         color,
         isWalk,
         isTransfer: entry.isTransfer,
+        name: leg.toName,
+        stopId: leg.toStopId,
+        arrival: leg.endTime,
+        scheduledArrival: leg.scheduledEndTime,
       );
     }
 
@@ -462,6 +538,7 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
     if (!_didAddStopsLayer) return;
 
     final stops = _collectRouteStops();
+    _stopsById.clear();
     if (stops.isEmpty) {
       try {
         await controller.setGeoJsonSource(
@@ -480,10 +557,12 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
         isTransfer: stop.isTransfer,
       );
       if (imageId == null) continue;
+      final featureId = i.toString();
+      _stopsById[featureId] = stop;
       features.add({
         'type': 'Feature',
         'id': i,
-        'properties': {'iconId': imageId, 'order': stop.order},
+        'properties': {'id': i, 'iconId': imageId, 'order': stop.order},
         'geometry': {
           'type': 'Point',
           'coordinates': [stop.point.longitude, stop.point.latitude],
@@ -587,7 +666,7 @@ class _ItineraryMapScreenState extends State<ItineraryMapScreen> {
             iconAnchor: 'center',
             symbolSortKey: [Expressions.get, 'order'],
           ),
-          enableInteraction: false,
+          enableInteraction: true,
         );
       }
       _didAddStopsLayer = true;
@@ -760,6 +839,167 @@ class _JourneySummaryCard extends StatelessWidget {
   }
 }
 
+class _StopInfoPopup extends StatelessWidget {
+  const _StopInfoPopup({
+    required this.stop,
+    required this.onDismiss,
+    required this.onSeeDepartures,
+  });
+
+  final _RouteStop stop;
+  final VoidCallback onDismiss;
+  final VoidCallback onSeeDepartures;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasArrival = stop.arrival != null || stop.scheduledArrival != null;
+    final hasDeparture =
+        stop.departure != null || stop.scheduledDeparture != null;
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 12, 10, 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x26000000),
+            blurRadius: 20,
+            offset: Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  stop.name?.isNotEmpty == true ? stop.name! : 'Stop',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.black,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (hasArrival || hasDeparture) ...[
+                  const SizedBox(height: 6),
+                  if (hasArrival)
+                    _StopTimeRow(
+                      label: 'Arrival',
+                      scheduled: stop.scheduledArrival,
+                      actual: stop.arrival,
+                    ),
+                  if (hasArrival && hasDeparture) const SizedBox(height: 2),
+                  if (hasDeparture)
+                    _StopTimeRow(
+                      label: 'Departure',
+                      scheduled: stop.scheduledDeparture,
+                      actual: stop.departure,
+                    ),
+                ] else ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    'No timetable information for this stop.',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: AppColors.black.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ],
+                if (stop.stopId != null) ...[
+                  const SizedBox(height: 8),
+                  GestureDetector(
+                    onTap: onSeeDepartures,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'See all departures',
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.accentOf(context),
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        Icon(
+                          LucideIcons.chevronRight,
+                          size: 14,
+                          color: AppColors.accentOf(context),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: onDismiss,
+            child: Padding(
+              padding: const EdgeInsets.all(4),
+              child: Icon(
+                LucideIcons.x,
+                size: 16,
+                color: AppColors.black.withValues(alpha: 0.5),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StopTimeRow extends StatelessWidget {
+  const _StopTimeRow({
+    required this.label,
+    required this.scheduled,
+    required this.actual,
+  });
+
+  final String label;
+  final DateTime? scheduled;
+  final DateTime? actual;
+
+  @override
+  Widget build(BuildContext context) {
+    final display = formatTime(scheduled ?? actual, nullPlaceholder: '--:--');
+    final delay = (scheduled != null && actual != null)
+        ? computeDelay(scheduled, actual!)
+        : null;
+    return Row(
+      children: [
+        Text(
+          '$label $display',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: AppColors.black.withValues(alpha: 0.8),
+          ),
+        ),
+        if (delay != null) ...[
+          const SizedBox(width: 6),
+          Text(
+            formatDelay(delay),
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: delayColor(delay),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
 class _RouteStop {
   const _RouteStop({
     required this.point,
@@ -767,6 +1007,12 @@ class _RouteStop {
     required this.order,
     required this.isWalk,
     required this.isTransfer,
+    this.name,
+    this.stopId,
+    this.arrival,
+    this.departure,
+    this.scheduledArrival,
+    this.scheduledDeparture,
   });
 
   final LatLng point;
@@ -774,6 +1020,12 @@ class _RouteStop {
   final int order;
   final bool isWalk;
   final bool isTransfer;
+  final String? name;
+  final String? stopId;
+  final DateTime? arrival;
+  final DateTime? departure;
+  final DateTime? scheduledArrival;
+  final DateTime? scheduledDeparture;
 }
 
 class _LegCarouselCard extends StatelessWidget {

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -58,6 +58,8 @@ import '../widgets/selectable_icon_card.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/skeletons/skeleton_card.dart';
 import '../widgets/skeletons/skeleton_shimmer.dart';
+import '../widgets/last_updated_footer.dart';
+import '../widgets/stop_departures_sheet.dart';
 import '../widgets/stop_schedule_row.dart';
 import '../widgets/timeline_indicator_box.dart';
 import '../widgets/map/long_press_selection_modal.dart';
@@ -186,6 +188,7 @@ class _MapScreenState extends State<MapScreen>
   String? _tripFocusError;
   String? _focusedTripId;
   Itinerary? _focusedItinerary;
+  DateTime? _tripFocusLastUpdated;
   bool _showStopsBeforeFocus = true;
   int _focusedTripRequestId = 0;
   final Map<String, _VehicleMarker> _focusedVehicles = {};
@@ -505,6 +508,7 @@ class _MapScreenState extends State<MapScreen>
     _focusedTripIds.clear();
     _focusedTripId = null;
     _focusedItinerary = null;
+    _tripFocusLastUpdated = null;
     _isTripFocus = false;
     _isQuickSettings = false;
     _isTripFocusLoading = false;
@@ -1812,6 +1816,9 @@ class _MapScreenState extends State<MapScreen>
                               isLoading: _isTripFocusLoading,
                               errorMessage: _tripFocusError,
                               bottomSpacer: bottomBarHeight,
+                              onStopTap: _openStopDeparturesSheet,
+                              onRefresh: _refreshTripFocus,
+                              lastUpdated: _tripFocusLastUpdated,
                             )
                           : _isQuickSettings
                           ? _QuickSettingsBottomCard(
@@ -3604,6 +3611,7 @@ class _MapScreenState extends State<MapScreen>
       _tripFocusError = null;
       _focusedTripId = tripId;
       _focusedItinerary = null;
+      _tripFocusLastUpdated = null;
       _focusedStopsColor = null;
       _showStops = false;
     });
@@ -3638,6 +3646,7 @@ class _MapScreenState extends State<MapScreen>
       _tripFocusError = null;
       _focusedTripId = null;
       _focusedItinerary = null;
+      _tripFocusLastUpdated = null;
       _focusedStopsColor = null;
       _showStops = _showStopsBeforeFocus;
     });
@@ -3657,6 +3666,33 @@ class _MapScreenState extends State<MapScreen>
     unawaited(_refreshRouteMarkers(allowFit: false));
     _scheduleTripRefresh();
     _scheduleStopRefresh();
+  }
+
+  void _openStopDeparturesSheet({
+    required String? stopId,
+    required String stopName,
+    required DateTime referenceTime,
+  }) {
+    if (stopId == null || stopId.isEmpty) return;
+
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Stop departures',
+      barrierColor: const Color(0x00000000),
+      transitionDuration: const Duration(milliseconds: 180),
+      pageBuilder: (context, _, __) {
+        return StopDeparturesSheet(
+          stopId: stopId,
+          stopName: stopName,
+          referenceTime: referenceTime,
+          onDismiss: () => Navigator.of(context, rootNavigator: true).pop(),
+        );
+      },
+      transitionBuilder: (context, animation, _, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+    );
   }
 
   void _openQuickSettings() {
@@ -3691,6 +3727,7 @@ class _MapScreenState extends State<MapScreen>
       setState(() {
         _focusedItinerary = itinerary;
         _isTripFocusLoading = false;
+        _tripFocusLastUpdated = DateTime.now();
       });
       _focusedStopsColor = _focusedRouteColor(itinerary);
       _focusedRouteKeys
@@ -3711,11 +3748,19 @@ class _MapScreenState extends State<MapScreen>
     } catch (e) {
       if (!mounted || requestId != _focusedTripRequestId) return;
       setState(() {
-        _focusedItinerary = null;
         _isTripFocusLoading = false;
-        _tripFocusError = 'Failed to load trip.';
+        // Keep showing the previously loaded trip if this was a refresh.
+        if (_focusedItinerary == null) {
+          _tripFocusError = 'Failed to load trip.';
+        }
       });
     }
+  }
+
+  Future<void> _refreshTripFocus() async {
+    final tripId = _focusedTripId;
+    if (tripId == null) return;
+    await _loadFocusedTripDetails(tripId);
   }
 
   Future<void> _pushFocusedVehicleSource(DateTime now) async {

--- a/lib/screens/map_screen/map_screen_trip_focus.dart
+++ b/lib/screens/map_screen/map_screen_trip_focus.dart
@@ -1,5 +1,12 @@
 part of '../map_screen.dart';
 
+typedef _OpenStopDeparturesSheet =
+    void Function({
+      required String? stopId,
+      required String stopName,
+      required DateTime referenceTime,
+    });
+
 class _TripFocusBottomCard extends StatelessWidget {
   const _TripFocusBottomCard({
     required this.onHandleTap,
@@ -11,6 +18,9 @@ class _TripFocusBottomCard extends StatelessWidget {
     required this.isLoading,
     required this.errorMessage,
     required this.bottomSpacer,
+    required this.onStopTap,
+    required this.onRefresh,
+    required this.lastUpdated,
   });
 
   final VoidCallback onHandleTap;
@@ -22,6 +32,9 @@ class _TripFocusBottomCard extends StatelessWidget {
   final bool isLoading;
   final String? errorMessage;
   final double bottomSpacer;
+  final _OpenStopDeparturesSheet onStopTap;
+  final Future<void> Function() onRefresh;
+  final DateTime? lastUpdated;
 
   @override
   Widget build(BuildContext context) {
@@ -48,13 +61,28 @@ class _TripFocusBottomCard extends StatelessWidget {
               onDragUpdate: onDragUpdate,
               onDragEnd: onDragEnd,
             ),
-            _BottomSheetBackButton(onPressed: onBack),
+            Stack(
+              alignment: Alignment.centerRight,
+              children: [
+                _BottomSheetBackButton(onPressed: onBack),
+                if (lastUpdated != null)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 16),
+                    child: LastUpdatedFooter(
+                      lastUpdated: lastUpdated,
+                      compact: true,
+                    ),
+                  ),
+              ],
+            ),
             Expanded(
               child: _TripFocusContent(
                 itinerary: itinerary,
                 isLoading: isLoading,
                 errorMessage: errorMessage,
                 bottomSpacer: bottomSpacer,
+                onStopTap: onStopTap,
+                onRefresh: onRefresh,
               ),
             ),
           ],
@@ -70,12 +98,16 @@ class _TripFocusContent extends StatelessWidget {
     required this.isLoading,
     required this.errorMessage,
     required this.bottomSpacer,
+    required this.onStopTap,
+    required this.onRefresh,
   });
 
   final Itinerary? itinerary;
   final bool isLoading;
   final String? errorMessage;
   final double bottomSpacer;
+  final _OpenStopDeparturesSheet onStopTap;
+  final Future<void> Function() onRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -191,448 +223,495 @@ class _TripFocusContent extends StatelessWidget {
       }
     }
 
-    return SingleChildScrollView(
-      padding: const EdgeInsets.only(bottom: 16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          CustomCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Icon(modeIcon, size: 32, color: AppColors.black),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          if (headerText.isNotEmpty)
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 10,
-                                vertical: 6,
-                              ),
-                              decoration: BoxDecoration(
-                                color: routeColor,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                              child: Text(
-                                headerText,
-                                style: TextStyle(
-                                  color: routeTextColor,
-                                  fontSize: 18,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                              ),
-                            ),
-                          if (headsign != null) ...[
-                            const SizedBox(height: 8),
-                            Text(
-                              '${getTransitModeName(focusLeg.mode)} • $headsign',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.black,
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          if (allAlerts.isNotEmpty) ...[
-            const SizedBox(height: 12),
-            CustomCard(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Warnings',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      color: AppColors.black,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  ...allAlerts.values.map((alert) {
-                    final hasTitle =
-                        alert.headerText != null &&
-                        alert.headerText!.isNotEmpty;
-                    final hasBody =
-                        alert.descriptionText != null &&
-                        alert.descriptionText!.isNotEmpty;
-
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 8),
-                      child: Container(
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: const Color(0xFFFFF3CD),
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(color: const Color(0xFFFFC107)),
-                        ),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Icon(
-                              LucideIcons.triangleAlert,
-                              size: 16,
-                              color: Color(0xFFF57C00),
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  if (hasTitle)
-                                    Text(
-                                      alert.headerText!,
-                                      style: TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.bold,
-                                        color: AppColors.black,
-                                      ),
-                                    ),
-                                  if (hasBody) ...[
-                                    if (hasTitle) const SizedBox(height: 2),
-                                    Text(
-                                      alert.descriptionText!,
-                                      style: TextStyle(
-                                        fontSize: 13,
-                                        color: AppColors.black.withValues(
-                                          alpha: 0.8,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                  }),
-                ],
-              ),
-            ),
-          ],
-          const SizedBox(height: 12),
-          CustomCard(
+    return CustomScrollView(
+      physics: const BouncingScrollPhysics(
+        parent: AlwaysScrollableScrollPhysics(),
+      ),
+      slivers: [
+        CupertinoSliverRefreshControl(onRefresh: onRefresh),
+        SliverPadding(
+          padding: const EdgeInsets.only(bottom: 16),
+          sliver: SliverToBoxAdapter(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Text(
-                  'Information',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.black,
+                CustomCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(modeIcon, size: 32, color: AppColors.black),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                if (headerText.isNotEmpty)
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 10,
+                                      vertical: 6,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: routeColor,
+                                      borderRadius: BorderRadius.circular(6),
+                                    ),
+                                    child: Text(
+                                      headerText,
+                                      style: TextStyle(
+                                        color: routeTextColor,
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    ),
+                                  ),
+                                if (headsign != null) ...[
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    '${getTransitModeName(focusLeg.mode)} • $headsign',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w600,
+                                      color: AppColors.black,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                if (allAlerts.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  CustomCard(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Warnings',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                            color: AppColors.black,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        ...allAlerts.values.map((alert) {
+                          final hasTitle =
+                              alert.headerText != null &&
+                              alert.headerText!.isNotEmpty;
+                          final hasBody =
+                              alert.descriptionText != null &&
+                              alert.descriptionText!.isNotEmpty;
+
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Container(
+                              padding: const EdgeInsets.all(12),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFFFFF3CD),
+                                borderRadius: BorderRadius.circular(8),
+                                border: Border.all(
+                                  color: const Color(0xFFFFC107),
+                                ),
+                              ),
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Icon(
+                                    LucideIcons.triangleAlert,
+                                    size: 16,
+                                    color: Color(0xFFF57C00),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        if (hasTitle)
+                                          Text(
+                                            alert.headerText!,
+                                            style: TextStyle(
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.bold,
+                                              color: AppColors.black,
+                                            ),
+                                          ),
+                                        if (hasBody) ...[
+                                          if (hasTitle)
+                                            const SizedBox(height: 2),
+                                          Text(
+                                            alert.descriptionText!,
+                                            style: TextStyle(
+                                              fontSize: 13,
+                                              color: AppColors.black.withValues(
+                                                alpha: 0.8,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        }),
+                      ],
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 12),
+                CustomCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        'Information',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.black,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          if (focusLeg.realTime)
+                            const InfoChip(
+                              icon: LucideIcons.radio,
+                              label: 'Real-time',
+                            ),
+                          if (focusLeg.cancelled == true)
+                            const InfoChip(
+                              icon: LucideIcons.x,
+                              label: 'CANCELLED',
+                              tint: Color(0xFFD32F2F),
+                            ),
+                          InfoChip(
+                            icon: LucideIcons.clock,
+                            label: formatDuration(focusLeg.duration),
+                          ),
+                          if (focusLeg.distance != null)
+                            InfoChip(
+                              icon: LucideIcons.ruler,
+                              label:
+                                  '${(focusLeg.distance! / 1000).toStringAsFixed(1)} km',
+                            ),
+                          if (focusLeg.agencyName != null)
+                            InfoChip(
+                              icon: LucideIcons.building,
+                              label: focusLeg.agencyName!,
+                            ),
+                          if (focusLeg.routeLongName != null &&
+                              focusLeg.routeLongName!.isNotEmpty)
+                            InfoChip(
+                              icon: LucideIcons.route,
+                              label: focusLeg.routeLongName!,
+                            ),
+                          if (itinerary.fare != null)
+                            InfoChip(
+                              icon: LucideIcons.coins,
+                              label:
+                                  '${itinerary.fare!.amount.toStringAsFixed(2)} ${itinerary.fare!.currency}',
+                            ),
+                        ],
+                      ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: 12),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    if (focusLeg.realTime)
-                      const InfoChip(
-                        icon: LucideIcons.radio,
-                        label: 'Real-time',
+                CustomCard(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Journey',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.black,
+                        ),
                       ),
-                    if (focusLeg.cancelled == true)
-                      const InfoChip(
-                        icon: LucideIcons.x,
-                        label: 'CANCELLED',
-                        tint: Color(0xFFD32F2F),
-                      ),
-                    InfoChip(
-                      icon: LucideIcons.clock,
-                      label: formatDuration(focusLeg.duration),
-                    ),
-                    if (focusLeg.distance != null)
-                      InfoChip(
-                        icon: LucideIcons.ruler,
-                        label:
-                            '${(focusLeg.distance! / 1000).toStringAsFixed(1)} km',
-                      ),
-                    if (focusLeg.agencyName != null)
-                      InfoChip(
-                        icon: LucideIcons.building,
-                        label: focusLeg.agencyName!,
-                      ),
-                    if (focusLeg.routeLongName != null &&
-                        focusLeg.routeLongName!.isNotEmpty)
-                      InfoChip(
-                        icon: LucideIcons.route,
-                        label: focusLeg.routeLongName!,
-                      ),
-                    if (itinerary.fare != null)
-                      InfoChip(
-                        icon: LucideIcons.coins,
-                        label:
-                            '${itinerary.fare!.amount.toStringAsFixed(2)} ${itinerary.fare!.currency}',
-                      ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 12),
-          CustomCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Journey',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.black,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                if (stops.isEmpty)
-                  EmptyState(
-                    title: 'No stops available',
-                    padding: EdgeInsets.zero,
-                    titleStyle: TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.black.withValues(alpha: 0.6),
-                    ),
-                  )
-                else
-                  FixedTimeline.tileBuilder(
-                    theme: TimelineThemeData(
-                      nodePosition: 0.08,
-                      color: routeColor,
-                      indicatorTheme: const IndicatorThemeData(size: 28),
-                      connectorTheme: const ConnectorThemeData(thickness: 2.5),
-                    ),
-                    builder: TimelineTileBuilder.connected(
-                      itemCount: timelineItems.length,
-                      connectionDirection: ConnectionDirection.before,
-                      contentsBuilder: (context, index) {
-                        final item = timelineItems[index];
-                        if (item.isVehicle && item.stop == null) {
-                          return const SizedBox.shrink();
-                        }
+                      const SizedBox(height: 16),
+                      if (stops.isEmpty)
+                        EmptyState(
+                          title: 'No stops available',
+                          padding: EdgeInsets.zero,
+                          titleStyle: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.black.withValues(alpha: 0.6),
+                          ),
+                        )
+                      else
+                        FixedTimeline.tileBuilder(
+                          theme: TimelineThemeData(
+                            nodePosition: 0.08,
+                            color: routeColor,
+                            indicatorTheme: const IndicatorThemeData(size: 28),
+                            connectorTheme: const ConnectorThemeData(
+                              thickness: 2.5,
+                            ),
+                          ),
+                          builder: TimelineTileBuilder.connected(
+                            itemCount: timelineItems.length,
+                            connectionDirection: ConnectionDirection.before,
+                            contentsBuilder: (context, index) {
+                              final item = timelineItems[index];
+                              if (item.isVehicle && item.stop == null) {
+                                return const SizedBox.shrink();
+                              }
 
-                        final stop = item.stop!;
-                        final stopIndex = stops.indexOf(stop);
-                        final isPassed = stopIndex <= currentStopIndex;
-                        final isUpcoming = stopIndex == upcomingStopIndex;
+                              final stop = item.stop!;
+                              final stopIndex = stops.indexOf(stop);
+                              final isPassed = stopIndex <= currentStopIndex;
+                              final isUpcoming = stopIndex == upcomingStopIndex;
 
-                        final arrRow = buildStopScheduleRow(
-                          'Arr',
-                          stop.scheduledArrival,
-                          stop.arrival,
-                          isPassed,
-                        );
-                        final depRow = buildStopScheduleRow(
-                          'Dep',
-                          stop.scheduledDeparture,
-                          stop.departure,
-                          isPassed,
-                        );
+                              final arrRow = buildStopScheduleRow(
+                                'Arr',
+                                stop.scheduledArrival,
+                                stop.arrival,
+                                isPassed,
+                              );
+                              final depRow = buildStopScheduleRow(
+                                'Dep',
+                                stop.scheduledDeparture,
+                                stop.departure,
+                                isPassed,
+                              );
 
-                        return Padding(
-                          padding: const EdgeInsets.only(left: 12, bottom: 16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Row(
-                                children: [
-                                  Expanded(
-                                    child: Text(
-                                      stop.name,
-                                      style: TextStyle(
-                                        fontSize: 14,
-                                        fontWeight:
-                                            stopIndex == 0 ||
-                                                stopIndex == stops.length - 1 ||
-                                                isUpcoming
-                                            ? FontWeight.w600
-                                            : FontWeight.normal,
-                                        color: isPassed
-                                            ? AppColors.black.withValues(
-                                                alpha: 0.5,
-                                              )
-                                            : AppColors.black,
+                              return GestureDetector(
+                                onTap: stop.stopId == null
+                                    ? null
+                                    : () => onStopTap(
+                                        stopId: stop.stopId,
+                                        stopName: stop.name,
+                                        referenceTime:
+                                            stop.departure ??
+                                            stop.arrival ??
+                                            DateTime.now().toUtc(),
                                       ),
-                                    ),
+                                child: Padding(
+                                  padding: const EdgeInsets.only(
+                                    left: 12,
+                                    bottom: 16,
                                   ),
-                                  if (isUpcoming) ...[
-                                    const SizedBox(width: 8),
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 6,
-                                        vertical: 2,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: routeColor.withValues(
-                                          alpha: 0.2,
-                                        ),
-                                        borderRadius: BorderRadius.circular(4),
-                                      ),
-                                      child: Text(
-                                        'Upcoming',
-                                        style: TextStyle(
-                                          fontSize: 11,
-                                          fontWeight: FontWeight.w700,
-                                          color: routeColor,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ],
-                              ),
-                              if (arrRow != null || depRow != null) ...[
-                                const SizedBox(height: 2),
-                                if (arrRow != null) arrRow,
-                                if (depRow != null) ...[
-                                  if (arrRow != null) const SizedBox(height: 2),
-                                  depRow,
-                                ],
-                              ],
-                              if (stop.track != null) ...[
-                                const SizedBox(height: 2),
-                                Text(
-                                  'Track ${stop.track}',
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    color: isPassed
-                                        ? AppColors.black.withValues(alpha: 0.4)
-                                        : AppColors.black.withValues(
-                                            alpha: 0.5,
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Row(
+                                        children: [
+                                          Expanded(
+                                            child: Text(
+                                              stop.name,
+                                              style: TextStyle(
+                                                fontSize: 14,
+                                                fontWeight:
+                                                    stopIndex == 0 ||
+                                                        stopIndex ==
+                                                            stops.length - 1 ||
+                                                        isUpcoming
+                                                    ? FontWeight.w600
+                                                    : FontWeight.normal,
+                                                color: isPassed
+                                                    ? AppColors.black
+                                                          .withValues(
+                                                            alpha: 0.5,
+                                                          )
+                                                    : AppColors.black,
+                                              ),
+                                            ),
                                           ),
+                                          if (isUpcoming) ...[
+                                            const SizedBox(width: 8),
+                                            Container(
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                    horizontal: 6,
+                                                    vertical: 2,
+                                                  ),
+                                              decoration: BoxDecoration(
+                                                color: routeColor.withValues(
+                                                  alpha: 0.2,
+                                                ),
+                                                borderRadius:
+                                                    BorderRadius.circular(4),
+                                              ),
+                                              child: Text(
+                                                'Upcoming',
+                                                style: TextStyle(
+                                                  fontSize: 11,
+                                                  fontWeight: FontWeight.w700,
+                                                  color: routeColor,
+                                                ),
+                                              ),
+                                            ),
+                                          ],
+                                        ],
+                                      ),
+                                      if (arrRow != null || depRow != null) ...[
+                                        const SizedBox(height: 2),
+                                        if (arrRow != null) arrRow,
+                                        if (depRow != null) ...[
+                                          if (arrRow != null)
+                                            const SizedBox(height: 2),
+                                          depRow,
+                                        ],
+                                      ],
+                                      if (stop.track != null) ...[
+                                        const SizedBox(height: 2),
+                                        Text(
+                                          'Track ${stop.track}',
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            color: isPassed
+                                                ? AppColors.black.withValues(
+                                                    alpha: 0.4,
+                                                  )
+                                                : AppColors.black.withValues(
+                                                    alpha: 0.5,
+                                                  ),
+                                          ),
+                                        ),
+                                      ],
+                                      if (stop.cancelled == true) ...[
+                                        const SizedBox(height: 2),
+                                        const Text(
+                                          'CANCELLED',
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            color: Color(0xFFD32F2F),
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                        ),
+                                      ],
+                                    ],
                                   ),
                                 ),
-                              ],
-                              if (stop.cancelled == true) ...[
-                                const SizedBox(height: 2),
-                                const Text(
-                                  'CANCELLED',
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    color: Color(0xFFD32F2F),
-                                    fontWeight: FontWeight.w600,
+                              );
+                            },
+                            indicatorBuilder: (context, index) {
+                              final item = timelineItems[index];
+                              if (item.isVehicle && item.stop == null) {
+                                return TimelineIndicatorBox(
+                                  lineColor: routeColor,
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      color: routeColor,
+                                      shape: BoxShape.circle,
+                                    ),
+                                    child: Center(
+                                      child: Icon(
+                                        modeIcon,
+                                        size: 14,
+                                        color: routeTextColor,
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              }
+
+                              final stop = item.stop!;
+                              final stopIndex = stops.indexOf(stop);
+                              final isPassed = stopIndex <= currentStopIndex;
+                              final bool isTerminal =
+                                  stopIndex == 0 ||
+                                  stopIndex == stops.length - 1;
+                              final double dotSize = isTerminal ? 16 : 12;
+                              final Color dotColor = isPassed
+                                  ? routeColor.withValues(alpha: 0.6)
+                                  : routeColor;
+                              final bool isVehicleHere =
+                                  showVehicle &&
+                                  isVehicleAtStation &&
+                                  stopIndex == vehicleStopIndex;
+                              final bool isFirstStop = stopIndex == 0;
+                              final bool isLastStop =
+                                  stopIndex == stops.length - 1;
+
+                              if (isVehicleHere) {
+                                return TimelineIndicatorBox(
+                                  lineColor: dotColor,
+                                  centerGap: 28.0,
+                                  cutTop: isFirstStop,
+                                  cutBottom: isLastStop,
+                                  child: Stack(
+                                    alignment: Alignment.center,
+                                    children: [
+                                      DotIndicator(
+                                        color: dotColor,
+                                        size: dotSize,
+                                      ),
+                                      Container(
+                                        width: 28,
+                                        height: 28,
+                                        decoration: BoxDecoration(
+                                          color: routeColor,
+                                          shape: BoxShape.circle,
+                                        ),
+                                        child: Icon(
+                                          modeIcon,
+                                          size: 14,
+                                          color: routeTextColor,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                              }
+
+                              return TimelineIndicatorBox(
+                                lineColor: dotColor,
+                                centerGap: dotSize,
+                                cutTop: isFirstStop,
+                                cutBottom: isLastStop,
+                                child: Center(
+                                  child: DotIndicator(
+                                    color: dotColor,
+                                    size: dotSize,
                                   ),
                                 ),
-                              ],
-                            ],
+                              );
+                            },
+                            connectorBuilder: (context, index, connectorType) {
+                              bool isPassed = false;
+                              if (index < timelineItems.length) {
+                                final item = timelineItems[index];
+                                if (item.isVehicle) {
+                                  isPassed = true;
+                                } else {
+                                  final stopIndex = stops.indexOf(item.stop!);
+                                  isPassed = stopIndex <= currentStopIndex;
+                                }
+                              }
+
+                              return SolidLineConnector(
+                                color: isPassed
+                                    ? routeColor.withValues(alpha: 0.6)
+                                    : routeColor,
+                              );
+                            },
                           ),
-                        );
-                      },
-                      indicatorBuilder: (context, index) {
-                        final item = timelineItems[index];
-                        if (item.isVehicle && item.stop == null) {
-                          return TimelineIndicatorBox(
-                            lineColor: routeColor,
-                            child: DecoratedBox(
-                              decoration: BoxDecoration(
-                                color: routeColor,
-                                shape: BoxShape.circle,
-                              ),
-                              child: Center(
-                                child: Icon(
-                                  modeIcon,
-                                  size: 14,
-                                  color: routeTextColor,
-                                ),
-                              ),
-                            ),
-                          );
-                        }
-
-                        final stop = item.stop!;
-                        final stopIndex = stops.indexOf(stop);
-                        final isPassed = stopIndex <= currentStopIndex;
-                        final bool isTerminal =
-                            stopIndex == 0 || stopIndex == stops.length - 1;
-                        final double dotSize = isTerminal ? 16 : 12;
-                        final Color dotColor = isPassed
-                            ? routeColor.withValues(alpha: 0.6)
-                            : routeColor;
-                        final bool isVehicleHere =
-                            showVehicle &&
-                            isVehicleAtStation &&
-                            stopIndex == vehicleStopIndex;
-                        final bool isFirstStop = stopIndex == 0;
-                        final bool isLastStop = stopIndex == stops.length - 1;
-
-                        if (isVehicleHere) {
-                          return TimelineIndicatorBox(
-                            lineColor: dotColor,
-                            centerGap: 28.0,
-                            cutTop: isFirstStop,
-                            cutBottom: isLastStop,
-                            child: Stack(
-                              alignment: Alignment.center,
-                              children: [
-                                DotIndicator(color: dotColor, size: dotSize),
-                                Container(
-                                  width: 28,
-                                  height: 28,
-                                  decoration: BoxDecoration(
-                                    color: routeColor,
-                                    shape: BoxShape.circle,
-                                  ),
-                                  child: Icon(
-                                    modeIcon,
-                                    size: 14,
-                                    color: routeTextColor,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          );
-                        }
-
-                        return TimelineIndicatorBox(
-                          lineColor: dotColor,
-                          centerGap: dotSize,
-                          cutTop: isFirstStop,
-                          cutBottom: isLastStop,
-                          child: Center(
-                            child: DotIndicator(color: dotColor, size: dotSize),
-                          ),
-                        );
-                      },
-                      connectorBuilder: (context, index, connectorType) {
-                        bool isPassed = false;
-                        if (index < timelineItems.length) {
-                          final item = timelineItems[index];
-                          if (item.isVehicle) {
-                            isPassed = true;
-                          } else {
-                            final stopIndex = stops.indexOf(item.stop!);
-                            isPassed = stopIndex <= currentStopIndex;
-                          }
-                        }
-
-                        return SolidLineConnector(
-                          color: isPassed
-                              ? routeColor.withValues(alpha: 0.6)
-                              : routeColor,
-                        );
-                      },
-                    ),
+                        ),
+                    ],
                   ),
+                ),
+                SizedBox(height: 100),
               ],
             ),
           ),
-          SizedBox(height: 100),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/lib/services/routing_service.dart
+++ b/lib/services/routing_service.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import '../constants/prefs_keys.dart';
 import '../environment.dart';
 import '../models/itinerary.dart';
 import '../models/time_selection.dart';
@@ -38,6 +40,25 @@ class RoutingService {
       'withFares': 'true',
       'useRoutedTransfers': 'true',
     };
+
+    final prefs = SharedPreferencesAsync();
+    final walkingSpeedKmh = await prefs.getDouble(
+      PrefsKeys.transitWalkingSpeed,
+    );
+    final transferBuffer = await prefs.getInt(PrefsKeys.transitTransferBuffer);
+    final selectedModes = await prefs.getStringList(
+      PrefsKeys.transitSelectedModes,
+    );
+
+    if (walkingSpeedKmh != null) {
+      params['pedestrianSpeed'] = (walkingSpeedKmh / 3.6).toStringAsFixed(3);
+    }
+    if (transferBuffer != null && transferBuffer > 0) {
+      params['additionalTransferTime'] = transferBuffer.toString();
+    }
+    if (selectedModes != null && selectedModes.isNotEmpty) {
+      params['transitModes'] = selectedModes.join(',');
+    }
 
     if (pageCursor != null) {
       params['pageCursor'] = pageCursor;

--- a/lib/utils/journey_utils.dart
+++ b/lib/utils/journey_utils.dart
@@ -7,6 +7,7 @@ List<JourneyStop> buildJourneyStops(Leg leg) {
   stops.add(
     JourneyStop(
       name: leg.fromName,
+      stopId: leg.fromStopId,
       lat: leg.fromLat,
       lon: leg.fromLon,
       arrival: null,
@@ -24,6 +25,7 @@ List<JourneyStop> buildJourneyStops(Leg leg) {
     stops.add(
       JourneyStop(
         name: stop.name,
+        stopId: stop.stopId,
         lat: stop.lat,
         lon: stop.lon,
         arrival: stop.arrival,
@@ -41,6 +43,7 @@ List<JourneyStop> buildJourneyStops(Leg leg) {
   stops.add(
     JourneyStop(
       name: leg.toName,
+      stopId: leg.toStopId,
       lat: leg.toLat,
       lon: leg.toLon,
       arrival: leg.endTime,

--- a/lib/widgets/last_updated_footer.dart
+++ b/lib/widgets/last_updated_footer.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_colors.dart';
+
+/// Small "Updated Xm ago" label shown on screens that support
+/// pull-to-refresh. Renders nothing until [lastUpdated] is set.
+///
+/// By default it's centered with vertical padding, meant for the bottom of
+/// a scrollable list. Pass [compact] to get a bare inline label instead,
+/// for placing somewhere always visible (e.g. next to a fixed header) so
+/// the user doesn't have to scroll to confirm a refresh happened.
+class LastUpdatedFooter extends StatelessWidget {
+  const LastUpdatedFooter({
+    super.key,
+    required this.lastUpdated,
+    this.compact = false,
+  });
+
+  final DateTime? lastUpdated;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final lastUpdated = this.lastUpdated;
+    if (lastUpdated == null) return const SizedBox.shrink();
+    final text = Text(
+      'Updated ${_formatAgo(lastUpdated)}',
+      style: TextStyle(
+        fontSize: 12,
+        color: AppColors.black.withValues(alpha: 0.4),
+      ),
+    );
+    if (compact) return text;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Center(child: text),
+    );
+  }
+
+  String _formatAgo(DateTime time) {
+    final diff = DateTime.now().difference(time);
+    if (diff.inSeconds < 45) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+}

--- a/lib/widgets/stop_departures_sheet.dart
+++ b/lib/widgets/stop_departures_sheet.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import '../models/stop_time.dart';
+import '../screens/connection_info_screen.dart';
+import '../services/stop_times_service.dart';
+import '../theme/app_colors.dart';
+import '../utils/color_utils.dart';
+import '../utils/custom_page_route.dart';
+import '../utils/leg_helper.dart';
+import '../utils/time_utils.dart';
+import 'bottom_overlay_card.dart';
+import 'pressable_highlight.dart';
+import 'skeletons/skeleton_shimmer.dart';
+
+/// Bottom sheet shown when a stop in the itinerary (or on the map) is
+/// tapped. Shows a live list of the stop's upcoming departures. Tolerant of
+/// a missing [stopId] and of empty/failed departures responses.
+class StopDeparturesSheet extends StatefulWidget {
+  const StopDeparturesSheet({
+    super.key,
+    required this.stopId,
+    required this.stopName,
+    required this.referenceTime,
+    required this.onDismiss,
+  });
+
+  final String? stopId;
+  final String stopName;
+  final DateTime referenceTime;
+  final VoidCallback onDismiss;
+
+  @override
+  State<StopDeparturesSheet> createState() => _StopDeparturesSheetState();
+}
+
+class _StopDeparturesSheetState extends State<StopDeparturesSheet> {
+  List<StopTime>? _departures;
+  bool _isLoading = false;
+  bool _hasError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadDepartures());
+  }
+
+  Future<void> _loadDepartures() async {
+    final stopId = widget.stopId;
+    if (stopId == null || stopId.isEmpty) return;
+
+    setState(() {
+      _isLoading = true;
+      _hasError = false;
+    });
+
+    try {
+      final response = await StopTimesService.fetchStopTimes(
+        stopId: stopId,
+        n: 8,
+        startTime: widget.referenceTime,
+      );
+      if (!mounted) return;
+      setState(() {
+        _departures = response.stopTimes;
+        _isLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _departures = const [];
+        _hasError = true;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _openConnection(String tripId) {
+    if (tripId.isEmpty) return;
+    widget.onDismiss();
+    Navigator.of(
+      context,
+    ).push(CustomPageRoute(child: ConnectionInfoScreen(tripId: tripId)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomOverlayCard(
+      title: widget.stopName,
+      onDismiss: widget.onDismiss,
+      maxHeightFactor: 0.75,
+      child: Flexible(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const _SectionLabel('Upcoming departures'),
+              const SizedBox(height: 8),
+              _buildDeparturesList(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDeparturesList() {
+    if (widget.stopId == null || widget.stopId!.isEmpty) {
+      return const _EmptyNote('No live departures available for this stop.');
+    }
+    if (_isLoading) {
+      return const _DeparturesLoadingSkeleton();
+    }
+    final departures = _departures;
+    if (departures == null || departures.isEmpty) {
+      return _EmptyNote(
+        _hasError
+            ? 'Could not load upcoming departures.'
+            : 'No upcoming departures found.',
+      );
+    }
+    return Column(
+      children: departures
+          .map(
+            (stopTime) => _DepartureTile(
+              stopTime: stopTime,
+              onTap: () => _openConnection(stopTime.tripId),
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.3,
+        color: AppColors.black.withValues(alpha: 0.5),
+      ),
+    );
+  }
+}
+
+class _EmptyNote extends StatelessWidget {
+  const _EmptyNote(this.message);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Text(
+        message,
+        style: TextStyle(
+          fontSize: 14,
+          color: AppColors.black.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+  }
+}
+
+class _DeparturesLoadingSkeleton extends StatelessWidget {
+  const _DeparturesLoadingSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonShimmer(
+      child: Column(
+        children: List.generate(
+          3,
+          (_) => Container(
+            margin: const EdgeInsets.only(bottom: 8),
+            height: 56,
+            decoration: BoxDecoration(
+              color: const Color(0xFFE2E7EC),
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DepartureTile extends StatelessWidget {
+  const _DepartureTile({required this.stopTime, required this.onTap});
+
+  final StopTime stopTime;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final place = stopTime.place;
+    final badgeColor = parseHexColorOrAccent(context, stopTime.routeColor);
+    final badgeTextColor =
+        parseHexColor(stopTime.routeTextColor) ?? AppColors.solidWhite;
+    final departure = place.scheduledDeparture ?? place.departure;
+    final actualDeparture = place.departure;
+    final delay = (departure != null && actualDeparture != null)
+        ? computeDelay(departure, actualDeparture)
+        : null;
+
+    return PressableHighlight(
+      onPressed: onTap,
+      borderRadius: BorderRadius.circular(12),
+      enableHaptics: false,
+      child: Container(
+        width: double.infinity,
+        margin: const EdgeInsets.only(bottom: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+        child: Row(
+          children: [
+            Icon(
+              getLegIcon(stopTime.mode),
+              size: 20,
+              color: AppColors.black.withValues(alpha: 0.5),
+            ),
+            const SizedBox(width: 10),
+            if (stopTime.displayName.isNotEmpty) ...[
+              Container(
+                constraints: const BoxConstraints(minWidth: 30),
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+                decoration: BoxDecoration(
+                  color: badgeColor,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  stopTime.displayName,
+                  style: TextStyle(
+                    color: badgeTextColor,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 10),
+            ],
+            Expanded(
+              child: Text(
+                stopTime.headsign,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.black,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  formatTime(departure, nullPlaceholder: '--:--'),
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.black,
+                  ),
+                ),
+                if (delay != null)
+                  Text(
+                    formatDelay(delay),
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: delayColor(delay),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Addressed issue #23: transit options (walking speed, transfer buffer, mode selection) are now applied
Addresses issue #2: stops are now clickable on list (upcoming departures) & map (trip stop times)
Further improvement related to #3: show when the live times of the currently displayed trip are updated, pull to refresh
Click route badge / name in the itinerary view to see the full trip